### PR TITLE
feat(RawReportsOnFile): 更良好的详情信息、基于文件视角的 JSON 格式

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,7 +6,6 @@ use crate::{
 use argh::FromArgs;
 use cargo_metadata::camino::Utf8PathBuf;
 use eyre::ContextCompat;
-use itertools::Itertools;
 use rayon::prelude::*;
 use std::fs::File;
 
@@ -78,11 +77,7 @@ impl Args {
             Emit::Json => {
                 let (tree, raw_reports) = json_treenode(&stats);
                 serde_json::to_writer(std::io::stdout(), &tree)?;
-                let reports = raw_reports
-                    .iter()
-                    .map(|(key, r)| (*key, r.to_serialization()))
-                    .collect_vec();
-                serde_json::to_writer(std::io::stdout(), &reports)?;
+                serde_json::to_writer(std::io::stdout(), &raw_reports)?;
             }
             Emit::JsonFile(p) => {
                 let (tree, raw_reports) = json_treenode(&stats);
@@ -93,11 +88,7 @@ impl Args {
                 let report_path = p
                     .clone()
                     .with_file_name(format!("{file_stem}_raw_reports.json"));
-                let reports = raw_reports
-                    .iter()
-                    .map(|(key, r)| (*key, r.to_serialization()))
-                    .collect_vec();
-                serde_json::to_writer(File::create(&*report_path)?, &reports)?;
+                serde_json::to_writer(File::create(&*report_path)?, &raw_reports)?;
             }
         }
         debug!(?self.emit, "Output emitted");

--- a/src/run_checker/snapshots/statistics-test-suite.json
+++ b/src/run_checker/snapshots/statistics-test-suite.json
@@ -1,28 +1,30 @@
-{
-  "key": "0",
-  "data": {
-    "user": "repos",
-    "repo": "os-checker-test-suite",
-    "package": "",
-    "total_count": 6,
-    "Unformatted(File)": 4,
-    "Unformatted(Line)": 6,
-    "Clippy(Warn)": 1,
-    "Clippy(Error)": 1
-  },
-  "children": [
-    {
-      "key": "1",
-      "data": {
-        "user": "repos",
-        "repo": "os-checker-test-suite",
-        "package": "os-checker-test-suite",
-        "total_count": 6,
-        "Unformatted(File)": 4,
-        "Clippy(Warn)": 1,
-        "Clippy(Error)": 1
-      },
-      "children": null
-    }
-  ]
-}
+[
+  {
+    "key": "0",
+    "data": {
+      "user": "repos",
+      "repo": "os-checker-test-suite",
+      "package": "",
+      "total_count": 6,
+      "Unformatted(File)": 4,
+      "Unformatted(Line)": 6,
+      "Clippy(Warn)": 1,
+      "Clippy(Error)": 1
+    },
+    "children": [
+      {
+        "key": "1",
+        "data": {
+          "user": "repos",
+          "repo": "os-checker-test-suite",
+          "package": "os-checker-test-suite",
+          "total_count": 6,
+          "Unformatted(File)": 4,
+          "Clippy(Warn)": 1,
+          "Clippy(Error)": 1
+        },
+        "children": null
+      }
+    ]
+  }
+]

--- a/src/run_checker/snapshots/statistics-test-suite_raw_reports.json
+++ b/src/run_checker/snapshots/statistics-test-suite_raw_reports.json
@@ -1,60 +1,49 @@
 [
-  [
-    0,
-    {
-      "fmt": {
-        "/rust/my/os-checker/repos/os-checker-test-suite/examples/need-clippy-fix.rs": [
+  {
+    "user": "repos",
+    "repo": "os-checker-test-suite",
+    "package": "os-checker-test-suite",
+    "raw_reports": [
+      {
+        "file": "examples/need-clippy-fix.rs",
+        "count": 1,
+        "fmt": [
           "file: /rust/my/os-checker/repos/os-checker-test-suite/examples/need-clippy-fix.rs (original lines from 2 to 2)\n-    _ = (123); \n+    _ = (123);\n"
         ],
-        "/rust/my/os-checker/repos/os-checker-test-suite/examples/need-fmt.rs": [
+        "clippy_warn": [],
+        "clippy_error": []
+      },
+      {
+        "file": "examples/need-fmt.rs",
+        "count": 1,
+        "fmt": [
           "file: /rust/my/os-checker/repos/os-checker-test-suite/examples/need-fmt.rs (original lines from 1 to 1)\n-fn main() {    println!(\"from example\");\n+fn main() {\n+    println!(\"from example\");\n"
         ],
-        "/rust/my/os-checker/repos/os-checker-test-suite/src/main.rs": [
+        "clippy_warn": [],
+        "clippy_error": []
+      },
+      {
+        "file": "src/main.rs",
+        "count": 3,
+        "fmt": [
           "file: /rust/my/os-checker/repos/os-checker-test-suite/src/main.rs (original lines from 4 to 5)\n- \n-println!(\"Hello, world!\");\n+    println!(\"Hello, world!\");\n"
         ],
-        "/rust/my/os-checker/repos/os-checker-test-suite/tests/need-fmt.rs": [
-          "file: /rust/my/os-checker/repos/os-checker-test-suite/tests/need-fmt.rs (original lines from 1 to 2)\n-fn main () {\n-  }\n+fn main() {}\n"
-        ]
-      },
-      "clippy_warn": {
-        "src/main.rs": [
+        "clippy_warn": [
           "warning: unused variable: `a`\n --> src/main.rs:2:9\n  |\n2 |     let a = 3.14;\n  |         ^ help: if this is intentional, prefix it with an underscore: `_a`\n  |\n  = note: `#[warn(unused_variables)]` on by default\n\n"
-        ]
-      },
-      "clippy_error": {
-        "src/main.rs": [
+        ],
+        "clippy_error": [
           "error: approximate value of `f{32, 64}::consts::PI` found\n --> src/main.rs:2:13\n  |\n2 |     let a = 3.14;\n  |             ^^^^\n  |\n  = help: consider using the constant directly\n  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#approx_constant\n  = note: `#[deny(clippy::approx_constant)]` on by default\n\n"
         ]
-      }
-    }
-  ],
-  [
-    1,
-    {
-      "fmt": {
-        "/rust/my/os-checker/repos/os-checker-test-suite/examples/need-clippy-fix.rs": [
-          "file: /rust/my/os-checker/repos/os-checker-test-suite/examples/need-clippy-fix.rs (original lines from 2 to 2)\n-    _ = (123); \n+    _ = (123);\n"
-        ],
-        "/rust/my/os-checker/repos/os-checker-test-suite/examples/need-fmt.rs": [
-          "file: /rust/my/os-checker/repos/os-checker-test-suite/examples/need-fmt.rs (original lines from 1 to 1)\n-fn main() {    println!(\"from example\");\n+fn main() {\n+    println!(\"from example\");\n"
-        ],
-        "/rust/my/os-checker/repos/os-checker-test-suite/src/main.rs": [
-          "file: /rust/my/os-checker/repos/os-checker-test-suite/src/main.rs (original lines from 4 to 5)\n- \n-println!(\"Hello, world!\");\n+    println!(\"Hello, world!\");\n"
-        ],
-        "/rust/my/os-checker/repos/os-checker-test-suite/tests/need-fmt.rs": [
+      },
+      {
+        "file": "tests/need-fmt.rs",
+        "count": 1,
+        "fmt": [
           "file: /rust/my/os-checker/repos/os-checker-test-suite/tests/need-fmt.rs (original lines from 1 to 2)\n-fn main () {\n-  }\n+fn main() {}\n"
-        ]
-      },
-      "clippy_warn": {
-        "src/main.rs": [
-          "warning: unused variable: `a`\n --> src/main.rs:2:9\n  |\n2 |     let a = 3.14;\n  |         ^ help: if this is intentional, prefix it with an underscore: `_a`\n  |\n  = note: `#[warn(unused_variables)]` on by default\n\n"
-        ]
-      },
-      "clippy_error": {
-        "src/main.rs": [
-          "error: approximate value of `f{32, 64}::consts::PI` found\n --> src/main.rs:2:13\n  |\n2 |     let a = 3.14;\n  |             ^^^^\n  |\n  = help: consider using the constant directly\n  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#approx_constant\n  = note: `#[deny(clippy::approx_constant)]` on by default\n\n"
-        ]
+        ],
+        "clippy_warn": [],
+        "clippy_error": []
       }
-    }
-  ]
+    ]
+  }
 ]

--- a/src/run_checker/tests.rs
+++ b/src/run_checker/tests.rs
@@ -30,16 +30,11 @@ file://repos/os-checker-test-suite:
         stat: stats,
     };
 
-    let mut raw_reports = Vec::new();
-    let tree = repo_stat.json(&mut 0, &mut raw_reports);
+    let (tree, raw_reports) = json_treenode(&[repo_stat]);
     expect_file!["./snapshots/statistics-test-suite.json"].assert_eq(&to_string_pretty(&tree)?);
 
-    let reports = raw_reports
-        .iter()
-        .map(|(key, raw)| (*key, raw.to_serialization()))
-        .collect_vec();
     expect_file!["./snapshots/statistics-test-suite_raw_reports.json"]
-        .assert_eq(&to_string_pretty(&reports)?);
+        .assert_eq(&to_string_pretty(&raw_reports)?);
 
     Ok(())
 }


### PR DESCRIPTION
e.g.

```json
[
  {
    "user": "repos",
    "repo": "os-checker-test-suite",
    "package": "os-checker-test-suite",
    "raw_reports": [
      {
        "file": "examples/need-clippy-fix.rs",
        "count": 1,
        "fmt": [
          "file: /rust/my/os-checker/repos/os-checker-test-suite/examples/need-clippy-fix.rs (original lines from 2 to 2)\n-    _ = (123); \n+    _ = (123);\n"
        ],
        "clippy_warn": [],
        "clippy_error": []
      },
      {
        "file": "examples/need-fmt.rs",
        "count": 1,
        "fmt": [
          "file: /rust/my/os-checker/repos/os-checker-test-suite/examples/need-fmt.rs (original lines from 1 to 1)\n-fn main() {    println!(\"from example\");\n+fn main() {\n+    println!(\"from example\");\n"
        ],
        "clippy_warn": [],
        "clippy_error": []
      },
      {
        "file": "src/main.rs",
        "count": 3,
        "fmt": [
          "file: /rust/my/os-checker/repos/os-checker-test-suite/src/main.rs (original lines from 4 to 5)\n- \n-println!(\"Hello, world!\");\n+    println!(\"Hello, world!\");\n"
        ],
        "clippy_warn": [
          "warning: unused variable: `a`\n --> src/main.rs:2:9\n  |\n2 |     let a = 3.14;\n  |         ^ help: if this is intentional, prefix it with an underscore: `_a`\n  |\n  = note: `#[warn(unused_variables)]` on by default\n\n"
        ],
        "clippy_error": [
          "error: approximate value of `f{32, 64}::consts::PI` found\n --> src/main.rs:2:13\n  |\n2 |     let a = 3.14;\n  |             ^^^^\n  |\n  = help: consider using the constant directly\n  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#approx_constant\n  = note: `#[deny(clippy::approx_constant)]` on by default\n\n"
        ]
      },
      {
        "file": "tests/need-fmt.rs",
        "count": 1,
        "fmt": [
          "file: /rust/my/os-checker/repos/os-checker-test-suite/tests/need-fmt.rs (original lines from 1 to 2)\n-fn main () {\n-  }\n+fn main() {}\n"
        ],
        "clippy_warn": [],
        "clippy_error": []
      }
    ]
  }
]
```
