### PR TITLE
feat: 初步支持 lockbud

### DIFF
--- a/src/repo/cmd.rs
+++ b/src/repo/cmd.rs
@@ -46,18 +46,32 @@ pub fn cargo_clippy(pkg: &Pkg) -> Resolve {
 /// 默认运行 cargo lockbud 的命令
 pub fn cargo_lockbud(pkg: &Pkg) -> Resolve {
     let target = pkg.target;
-    // 只分析传入 toml path 指向的 package，不分析其依赖
+
+    // // 由于 cargo build 进行增量编译时，不输出旧 MIR，
+    // // lockbud 无法检查。因此要么不增量编译，要么 cargo clean，要么
+    // // 单独放置编译目录放置来不影响别的检查的增量编译。
+    // let mut lockbud_dir = pkg.dir.to_owned();
+    // lockbud_dir.extend(["__lockbud__", pkg.target]);
+
     let expr = cmd!(
         "cargo",
         "+nightly-2024-05-21",
         "lockbud",
+        "-k",
+        "all",
         "--",
         "--target",
         target,
+        // "--target-dir",
+        // &lockbud_dir
     )
     .dir(pkg.dir);
     debug!(?expr);
-    let cmd = format!("cargo +nightly-2024-05-21 lockbud -- --target {target}");
+    // let cmd = format!(
+    //     "cargo +nightly-2024-05-21 lockbud -k all \
+    //      -- --target {target} --target-dir={lockbud_dir}"
+    // );
+    let cmd = format!("cargo +nightly-2024-05-21 lockbud -k all -- --target {target}");
     Resolve::new(pkg, CheckerTool::Lockbud, cmd, expr)
 }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -216,6 +216,12 @@ impl RepoConfig {
             Some(Action::Lines(lines)) => Resolve::custom(pkgs, lines, Clippy, &mut v)?,
             _ => (),
         }
+        match &self.lockbud {
+            Some(Action::Perform(true)) => Resolve::lockbud(pkgs, &mut v),
+            None if all => Resolve::lockbud(pkgs, &mut v),
+            Some(Action::Lines(lines)) => Resolve::custom(pkgs, lines, Lockbud, &mut v)?,
+            _ => (),
+        }
 
         Ok(v)
     }

--- a/src/repo/validate.rs
+++ b/src/repo/validate.rs
@@ -6,7 +6,7 @@
 //!     * 如果指定包名，则校验是否定义于仓库内：需要 repo layout 信息
 //!     * 如果指定 features，则校验是否定义于 package 内：需要 cargo metadata 信息
 
-use super::{cargo_clippy, cargo_fmt, custom, CheckerTool};
+use super::{cargo_clippy, cargo_fmt, cargo_lockbud, custom, CheckerTool};
 use crate::{layout::Pkg, Result, XString};
 use cargo_metadata::camino::Utf8PathBuf;
 use duct::Expression;
@@ -69,6 +69,10 @@ impl Resolve {
 
     pub fn clippy(pkgs: &[Pkg], resolved: &mut Vec<Self>) {
         resolved.extend(pkgs.iter().map(cargo_clippy));
+    }
+
+    pub fn lockbud(pkgs: &[Pkg], resolved: &mut Vec<Self>) {
+        resolved.extend(pkgs.iter().map(cargo_lockbud));
     }
 
     pub fn custom(

--- a/src/run_checker/lockbud.rs
+++ b/src/run_checker/lockbud.rs
@@ -1,0 +1,30 @@
+use super::CargoMessage;
+
+#[cfg(test)]
+pub fn get_lockbud_result() -> crate::Result<String> {
+    let out = duct::cmd!("cargo", "+nightly-2024-05-21", "lockbud", "-k", "all")
+        .dir("repos/os-checker-test-suite")
+        .stderr_capture()
+        .run()?;
+    Ok(parse_lockbud_result(&out.stderr))
+}
+
+pub fn parse_lockbud_result(stderr: &[u8]) -> String {
+    let tag = "[2024"; // 目前只能通过日志识别
+    let mut count = 0usize;
+    let mut v = Vec::new();
+    for mes in CargoMessage::parse_stream(stderr).flatten() {
+        if let cargo_metadata::Message::TextLine(line) = mes {
+            if line.starts_with(tag) {
+                count += 1;
+            }
+            if count != 0 {
+                v.push(line);
+            }
+            if count == 2 {
+                count = 0;
+            }
+        }
+    }
+    v.join("\n")
+}

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -11,6 +11,7 @@ use regex::Regex;
 use serde::Deserialize;
 use std::{process::Output as RawOutput, sync::LazyLock};
 
+mod lockbud;
 /// 把获得的输出转化成 JSON 所需的输出
 mod utils;
 
@@ -179,9 +180,9 @@ fn run_check(resolve: Resolve) -> Result<Output> {
                 })
                 .collect::<Result<_>>()?,
         ),
+        CheckerTool::Lockbud => OutputParsed::Lockbud(lockbud::parse_lockbud_result(&raw.stderr)),
         CheckerTool::Miri => todo!(),
         CheckerTool::SemverChecks => todo!(),
-        CheckerTool::Lockbud => todo!(),
     };
     let count = parsed.count();
     Ok(Output {
@@ -197,6 +198,7 @@ fn run_check(resolve: Resolve) -> Result<Output> {
 pub enum OutputParsed {
     Fmt(Box<[FmtMessage]>),
     Clippy(Box<[ClippyMessage]>),
+    Lockbud(String),
 }
 
 impl OutputParsed {
@@ -232,6 +234,13 @@ impl OutputParsed {
                     _ => None,
                 })
                 .sum(),
+            OutputParsed::Lockbud(s) => {
+                if s.is_empty() {
+                    0
+                } else {
+                    1
+                }
+            }
         }
     }
 }

--- a/src/run_checker/tests.rs
+++ b/src/run_checker/tests.rs
@@ -75,3 +75,10 @@ fn jq_count(json_bytes: &[u8]) -> Result<String> {
 
     Ok(String::from_utf8(out1.stdout)?)
 }
+
+#[test]
+fn lockbud_output() -> Result<()> {
+    let s = super::lockbud::get_lockbud_result()?;
+    println!("{s}");
+    Ok(())
+}

--- a/src/run_checker/utils.rs
+++ b/src/run_checker/utils.rs
@@ -49,6 +49,16 @@ fn push_data(out: &RawOutput, with: WithData) {
     match &out.parsed {
         OutputParsed::Fmt(v) => push_unformatted(v, with),
         OutputParsed::Clippy(v) => push_clippy(v, with),
+        OutputParsed::Lockbud(s) => {
+            if !s.is_empty() {
+                with.data.push(Data {
+                    cmd_idx: with.cmd_idx,
+                    file: "Not supported to display yet.".into(),
+                    kind: Kind::Lockbud,
+                    raw: s.clone(),
+                });
+            }
+        }
     };
 }
 


### PR DESCRIPTION
ref: https://github.com/os-checker/os-checker/issues/34

这里的 file/kind/raw 需要将 lockbud 的 report 类型拆分出来，才能更美观。


```json
{
  "cmd_idx": 2,
  "file": "Not supported to display yet.",
  "kind": "Lockbud",
  "raw": "[2024-08-28T12:06:02Z WARN  lockbud::callbacks] [\n      {\n        \"UseAfterFree\": {\n          \"bug_kind\": \"UseAfterFree\",\n          \"possibility\": \"Possibly\",\n          \"diagnosis\": \"Raw ptr is used at src/main.rs:16:28: 16:32 (https://github.com/os-checker/os-checker/discussions/7) after dropped at src/main.rs:13:5: 13:6 (#0)\",\n       \"explanation\": \"Raw ptr is used or escapes the current function after the pointed value is dropped\"\n        }\n      },\n      {\n        \"UseAfterFree\": {\n          \"bug_kind\": \"UseAfterFree\",\n          \"possibility\": \"Possibly\",\n          \"diagnosis\": \"Raw ptr is used at src/main.rs:15:13: 15:26 (#0) after dropped at src/main.rs:13:5: 13:6 (#0)\",\n          \"explanation\": \"Raw ptr is used or escapes the current function after the pointed value is dropped\"\n        }\n      }\n    ]\n[2024-08-28T12:06:02Z WARN  lockbud::callbacks] crate os_checker_test_suite contains bugs: { probably: 0, possibly: 0 }, conflictlock: { probably: 0, possibly: 0 }, condvar_deadlock: { probably: 0, possibly: 0 }, atomicity_violation: { possibly: 0 }, invalid_free: { possibly: 0 }, use_after_free: { possibly: 2 }"
}
```