### PR TITLE
feat: 记录每组检查的 InfoKey

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,8 +19,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
-  CONFIGS: repos.json # for debug single repo
-  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  # CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,8 +19,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
-  # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  CONFIGS: repos.json # for debug single repo
+  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:
@@ -40,7 +40,7 @@ jobs:
           cp assets/repos-default.json ~/check/
           cp assets/repos-embassy.json ~/check/
           cd ~/check
-          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
+          # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
           # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb.tar.xz
           # tar -xJvf cache.redb.tar.xz
           ls -alh
@@ -88,8 +88,8 @@ jobs:
           cd ~/check
           make clone_database
           cd database
-          # git switch debug
-          # echo "切换到 debug 分支"
+          git switch debug
+          echo "切换到 debug 分支"
           git pull --rebase # 防止二次运行 CI 时落后于远程分支
 
           rm -rf batch # 移除旧的 batch 数据

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -2,7 +2,7 @@ name: Run Checkers
 
 on:
   push:
-    branches: [ main, feat/db-resolved-count ]
+    branches: [ main, feat/db-checks ]
 
 env:
   # gh cli needs this token
@@ -15,7 +15,7 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # cache.redb tag in database release
-  TAG_CACHE: cache-v3.redb # cache.redb # cache-v2.redb
+  TAG_CACHE: cache-v4.redb # cache.redb # cache-v2.redb
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
@@ -62,9 +62,11 @@ jobs:
           git lfs install --skip-smudge # 如果 lfs 下载不了大文件，跳过下载
           df -alh
           cd ~/check
+          os-checker db --start cache.redb
           # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
           batch --size 8 || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          os-checker db --done cache.redb
 
       - name: Run cache_redb test
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,8 +19,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
-  # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  CONFIGS: repos.json # for debug single repo
+  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:
@@ -40,7 +40,7 @@ jobs:
           cp assets/repos-default.json ~/check/
           cp assets/repos-embassy.json ~/check/
           cd ~/check
-          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
+          # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
           # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb.tar.xz
           # tar -xJvf cache.redb.tar.xz
           ls -alh

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -40,7 +40,7 @@ jobs:
           cp assets/repos-default.json ~/check/
           cp assets/repos-embassy.json ~/check/
           cd ~/check
-          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
+          # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
           # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb.tar.xz
           # tar -xJvf cache.redb.tar.xz
           ls -alh

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -40,7 +40,7 @@ jobs:
           cp assets/repos-default.json ~/check/
           cp assets/repos-embassy.json ~/check/
           cd ~/check
-          # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
+          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
           # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb.tar.xz
           # tar -xJvf cache.redb.tar.xz
           ls -alh

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,4 +1,3 @@
 {
-  "os-checker/os-checker-test-suite": {},
-  "elliott10/lwext4_rust": {}
+  "os-checker/os-checker-test-suite": {}
 }

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -20,6 +20,8 @@ struct Batch {
     size: String,
 }
 
+const DB: &str = "cache.redb";
+
 #[instrument(level = "trace")]
 fn main() -> Result<()> {
     logger::init();
@@ -69,7 +71,7 @@ fn main() -> Result<()> {
                 "--emit",
                 emit.as_str(),
                 "--db",
-                "cache.redb"
+                DB
             );
             info!(cmd = ?expr);
             expr.run()?;
@@ -86,10 +88,10 @@ fn main() -> Result<()> {
 
 fn upload_cache() -> Result<()> {
     // cmd!("ls", "-alh").run()?;
-    let tag = var("TAG_CACHE").unwrap_or_else(|_| "cache.redb".to_owned());
-    let args = format!("release upload --clobber -R os-checker/database {tag} cache.redb");
+    let tag = var("TAG_CACHE").unwrap();
+    let args = format!("release upload --clobber -R os-checker/database {tag} {DB}");
     cmd("gh", args.split(" ")).run()?;
-    info!("Successfully upload cache.redb.");
+    info!("Successfully upload {DB}.");
     Ok(())
 }
 

--- a/os-checker-database/src/db/mod.rs
+++ b/os-checker-database/src/db/mod.rs
@@ -2,7 +2,12 @@ use crate::{
     utils::{new_map_with_cap, IndexMap},
     Result,
 };
-use redb::{Key, ReadTransaction, ReadableTable, ReadableTableMetadata, TableDefinition, Value};
+use eyre::ContextCompat;
+use os_checker_types::db::*;
+use redb::{
+    Key, ReadOnlyTable, ReadTransaction, ReadableTable, ReadableTableMetadata, TableDefinition,
+    Value,
+};
 use std::{fmt::Debug, hash::Hash};
 
 // TODO: move this to os_checker_types crate
@@ -26,6 +31,67 @@ where
     }
 
     Ok(())
+}
+
+pub fn read_last_checks(txn: &ReadTransaction) -> Result<(u32, CheckValue)> {
+    let table = txn.open_table(CHECKS)?;
+    let last_checks = table
+        .last()?
+        .with_context(|| format!("{CHECKS} has no check item."))?;
+    let idx = last_checks.0.value();
+    info!(idx, %CHECKS, "Read last check item.");
+    Ok((idx, last_checks.1.value()))
+}
+
+pub struct LastChecks<'txn> {
+    txn: &'txn ReadTransaction,
+    checks: CheckValue,
+    layout: ReadOnlyTable<InfoKey, CacheLayout>,
+    cache: ReadOnlyTable<CacheRepoKey, CacheValue>,
+}
+
+impl<'txn> LastChecks<'txn> {
+    pub fn new(txn: &'txn ReadTransaction) -> Result<Self> {
+        let (_, checks) = read_last_checks(txn)?;
+        let layout = txn.open_table(LAYOUT)?;
+        let cache = txn.open_table(DATA)?;
+        Ok(Self {
+            txn,
+            checks,
+            layout,
+            cache,
+        })
+    }
+
+    pub fn repo_counts(&self) -> usize {
+        self.checks.keys.len()
+    }
+
+    pub fn with_layout_cache(
+        &self,
+        mut f: impl FnMut(&InfoKey, &[CacheRepoKey]) -> Result<()>,
+    ) -> Result<()> {
+        for key in &self.checks.keys {
+            f(&key.info, &key.cache)?;
+        }
+        Ok(())
+    }
+
+    pub fn read_layout(&self, info_key: &InfoKey) -> Result<CacheLayout> {
+        let _span = error_span!("read_layout", ?info_key).entered();
+        let guard = self.layout.get(info_key)?;
+        Ok(guard
+            .with_context(|| "Info key refers to None value.")?
+            .value())
+    }
+
+    pub fn read_cache(&self, cache_key: &CacheRepoKey) -> Result<CacheValue> {
+        let _span = error_span!("read_cache", ?cache_key).entered();
+        let guard = self.cache.get(cache_key)?;
+        Ok(guard
+            .with_context(|| "Cache key refers to None value.")?
+            .value())
+    }
 }
 
 fn count_key<K: Hash + Eq + Debug>(k: K, map: &mut IndexMap<K, u8>) {

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -80,9 +80,10 @@ pub struct Keys {
 
 impl fmt::Debug for Keys {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let repo = &self.info.repo;
         f.debug_struct("Keys")
             .field("cache.len", &self.cache.len())
-            .field("info", &self.info)
+            .field("info.repo", &repo.user_repo())
             .finish()
     }
 }

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -13,6 +13,16 @@ pub struct CheckValue {
     pub timestamp_end: u64,
 }
 
+impl Default for CheckValue {
+    fn default() -> Self {
+        Self {
+            keys: vec![],
+            timestamp_start: now(),
+            timestamp_end: 0,
+        }
+    }
+}
+
 redb_value!(CheckValue, name: "OsCheckerCheckValue",
     read_err: "Not a valid check value.",
     write_err: "Check value can't be encoded to bytes.");

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -1,7 +1,4 @@
-use crate::{
-    db::{CacheRepoKey, InfoKey},
-    prelude::*,
-};
+use crate::{db::InfoKey, prelude::*};
 
 #[derive(Encode, Decode)]
 pub struct CheckValue {
@@ -55,16 +52,7 @@ impl CheckValue {
 
     /// Should be called once a new repo is being checked.
     pub fn push_info_key(&mut self, info: InfoKey) {
-        self.keys.push(Keys {
-            cache: vec![],
-            info,
-        });
-    }
-
-    /// NOTE: push_info_key must be called before this function is called.
-    /// This function also means a checking is done.
-    pub fn push_cache_key(&mut self, cache: CacheRepoKey) {
-        self.keys.last_mut().unwrap().cache.push(cache);
+        self.keys.push(Keys { info });
     }
 }
 
@@ -74,7 +62,6 @@ redb_value!(CheckValue, name: "OsCheckerCheckValue",
 
 #[derive(Encode, Decode)]
 pub struct Keys {
-    pub cache: Vec<CacheRepoKey>,
     pub info: InfoKey,
 }
 
@@ -82,7 +69,6 @@ impl fmt::Debug for Keys {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let [user, repo] = &self.info.repo.user_repo();
         f.debug_struct("Keys")
-            .field("cache.len", &self.cache.len())
             .field("info.repo", &format!("{user}/{repo}"))
             .finish()
     }

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -23,6 +23,30 @@ impl Default for CheckValue {
     }
 }
 
+impl CheckValue {
+    pub fn set_complete(&mut self) {
+        self.timestamp_end = now();
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.timestamp_end == 0
+    }
+
+    /// Should be called once a new repo is being checked.
+    pub fn push_info_key(&mut self, info: InfoKey) {
+        self.keys.push(Keys {
+            cache: vec![],
+            info,
+        });
+    }
+
+    /// NOTE: push_info_key must be called before this function is called.
+    /// This function also means a checking is done.
+    pub fn push_cache_key(&mut self, cache: CacheRepoKey) {
+        self.keys.last_mut().unwrap().cache.push(cache);
+    }
+}
+
 redb_value!(CheckValue, name: "OsCheckerCheckValue",
     read_err: "Not a valid check value.",
     write_err: "Check value can't be encoded to bytes.");

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -80,10 +80,10 @@ pub struct Keys {
 
 impl fmt::Debug for Keys {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let repo = &self.info.repo;
+        let [user, repo] = &self.info.repo.user_repo();
         f.debug_struct("Keys")
             .field("cache.len", &self.cache.len())
-            .field("info.repo", &repo.user_repo())
+            .field("info.repo", &format!("{user}/{repo}"))
             .finish()
     }
 }

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -48,6 +48,11 @@ impl CheckValue {
         self.timestamp_end == 0
     }
 
+    pub fn is_same_keys(&self, other: &Self) -> bool {
+        // We could use PartialEq to do the comparison, but for simplicity, compare bytes here.
+        musli::storage::to_vec(&self.keys).unwrap() == musli::storage::to_vec(&other.keys).unwrap()
+    }
+
     /// Should be called once a new repo is being checked.
     pub fn push_info_key(&mut self, info: InfoKey) {
         self.keys.push(Keys {

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -1,0 +1,24 @@
+use crate::{
+    db::{CacheRepoKey, InfoKey},
+    prelude::*,
+};
+
+#[derive(Encode, Decode, Debug)]
+pub struct CheckValue {
+    pub keys: Vec<Keys>,
+    /// The unix timestmap in milliseconds.
+    pub timestamp_start: u64,
+    /// The default is 0 and means all checks are not finished.
+    /// The value should be updated once checks are done.
+    pub timestamp_end: u64,
+}
+
+redb_value!(CheckValue, name: "OsCheckerCheckValue",
+    read_err: "Not a valid check value.",
+    write_err: "Check value can't be encoded to bytes.");
+
+#[derive(Encode, Decode, Debug)]
+pub struct Keys {
+    pub cache: Vec<CacheRepoKey>,
+    pub info: InfoKey,
+}

--- a/os-checker-types/src/checks.rs
+++ b/os-checker-types/src/checks.rs
@@ -3,7 +3,7 @@ use crate::{
     prelude::*,
 };
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode)]
 pub struct CheckValue {
     pub keys: Vec<Keys>,
     /// The unix timestmap in milliseconds.
@@ -11,6 +11,22 @@ pub struct CheckValue {
     /// The default is 0 and means all checks are not finished.
     /// The value should be updated once checks are done.
     pub timestamp_end: u64,
+}
+
+impl fmt::Debug for CheckValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CheckValue")
+            .field("keys.len", &self.keys.len())
+            .field(
+                "timestamp_start",
+                &parse_unix_timestamp_milli(self.timestamp_start),
+            )
+            .field(
+                "timestamp_end",
+                &parse_unix_timestamp_milli(self.timestamp_end),
+            )
+            .finish()
+    }
 }
 
 impl Default for CheckValue {
@@ -51,8 +67,17 @@ redb_value!(CheckValue, name: "OsCheckerCheckValue",
     read_err: "Not a valid check value.",
     write_err: "Check value can't be encoded to bytes.");
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode)]
 pub struct Keys {
     pub cache: Vec<CacheRepoKey>,
     pub info: InfoKey,
+}
+
+impl fmt::Debug for Keys {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Keys")
+            .field("cache.len", &self.cache.len())
+            .field("info", &self.info)
+            .finish()
+    }
 }

--- a/os-checker-types/src/info.rs
+++ b/os-checker-types/src/info.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, Encode, Decode, Clone)]
 pub struct InfoKey {
     pub repo: crate::db::CacheRepo,
     #[musli(with = musli::serde)]

--- a/os-checker-types/src/lib.rs
+++ b/os-checker-types/src/lib.rs
@@ -6,6 +6,7 @@ mod toolchain;
 pub use toolchain::*;
 
 pub mod cache;
+pub mod checks;
 pub mod config;
 pub mod info;
 pub mod layout;
@@ -13,6 +14,7 @@ pub mod table;
 
 pub mod db {
     pub use crate::cache::*;
+    pub use crate::checks::*;
     pub use crate::config::RepoConfig;
     pub use crate::info::*;
     pub use crate::layout::*;

--- a/os-checker-types/src/prelude.rs
+++ b/os-checker-types/src/prelude.rs
@@ -7,6 +7,12 @@ pub use std::fmt;
 
 use time::OffsetDateTime;
 
+/// Returns the current unix timestamp in milliseconds.
+pub fn now() -> u64 {
+    let t = time::OffsetDateTime::from(std::time::SystemTime::now());
+    unix_timestamp_milli(t)
+}
+
 pub fn unix_timestamp_milli(t: OffsetDateTime) -> u64 {
     let milli = t.millisecond() as u64;
     let unix_t_secs = t.unix_timestamp() as u64;

--- a/os-checker-types/src/table.rs
+++ b/os-checker-types/src/table.rs
@@ -1,6 +1,7 @@
 use crate::db::*;
 use redb::{Database, TableDefinition};
 
+pub const CHECKS: TableDefinition<u32, CheckValue> = TableDefinition::new("checks");
 pub const DATA: TableDefinition<CacheRepoKey, CacheValue> = TableDefinition::new("data");
 pub const INFO: TableDefinition<InfoKey, Info> = TableDefinition::new("info");
 pub const LAYOUT: TableDefinition<InfoKey, CacheLayout> = TableDefinition::new("layout");

--- a/os-checker-types/src/tests.rs
+++ b/os-checker-types/src/tests.rs
@@ -14,7 +14,7 @@ fn cache_redb() -> Result<()> {
     let last_checks = table.last()?.unwrap();
     let id = last_checks.0.value();
     let checks = last_checks.1.value();
-    dbg!(id, checks);
+    dbg!(id, &checks, &checks.keys);
 
     stats(DATA, &txn)?;
     stats(INFO, &txn)?;

--- a/os-checker-types/src/tests.rs
+++ b/os-checker-types/src/tests.rs
@@ -14,7 +14,7 @@ fn cache_redb() -> Result<()> {
     let last_checks = table.last()?.unwrap();
     let id = last_checks.0.value();
     let checks = last_checks.1.value();
-    info!(id, ?checks, ?checks.keys);
+    dbg!(id, &checks, &checks.keys);
 
     stats(DATA, &txn)?;
     stats(INFO, &txn)?;

--- a/os-checker-types/src/tests.rs
+++ b/os-checker-types/src/tests.rs
@@ -14,7 +14,7 @@ fn cache_redb() -> Result<()> {
     let last_checks = table.last()?.unwrap();
     let id = last_checks.0.value();
     let checks = last_checks.1.value();
-    dbg!(checks);
+    dbg!(id, checks);
 
     stats(DATA, &txn)?;
     stats(INFO, &txn)?;

--- a/os-checker-types/src/tests.rs
+++ b/os-checker-types/src/tests.rs
@@ -14,7 +14,7 @@ fn cache_redb() -> Result<()> {
     let last_checks = table.last()?.unwrap();
     let id = last_checks.0.value();
     let checks = last_checks.1.value();
-    dbg!(id, &checks, &checks.keys);
+    info!(id, ?checks, ?checks.keys);
 
     stats(DATA, &txn)?;
     stats(INFO, &txn)?;

--- a/os-checker-types/src/tests.rs
+++ b/os-checker-types/src/tests.rs
@@ -9,6 +9,13 @@ fn cache_redb() -> Result<()> {
 
     let txn = db.begin_read()?;
 
+    stats(CHECKS, &txn)?;
+    let table = txn.open_table(CHECKS)?;
+    let last_checks = table.last()?.unwrap();
+    let id = last_checks.0.value();
+    let checks = last_checks.1.value();
+    dbg!(checks);
+
     stats(DATA, &txn)?;
     stats(INFO, &txn)?;
     stats(LAYOUT, &txn)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -343,7 +343,7 @@ struct ArgsDb {
     #[argh(switch)]
     done: bool,
     /// redb file path; this will be created if not exists
-    #[argh(option)]
+    #[argh(positional)]
     db: Utf8PathBuf,
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -50,6 +50,7 @@ impl Args {
             }
             SubArgs::Batch(batch) => batch.execute()?,
             SubArgs::Schema(schema) => gen_schema(&schema.path)?,
+            SubArgs::Db(db) => db.execute()?,
         }
         Ok(())
     }
@@ -73,6 +74,7 @@ enum SubArgs {
     Run(ArgsRun),
     Batch(ArgsBatch),
     Schema(ArgsSchema),
+    Db(ArgsDb),
 }
 
 /// Display the layouts without installing toolchains or checkers.
@@ -257,6 +259,7 @@ impl ArgsRun {
         // 丢弃其他数据库句柄
         drop(outs);
         // 压缩缓存数据库文件
+        // FIXME: this moves to db --done
         if let Some(db) = db {
             db.compact();
         }
@@ -327,4 +330,32 @@ pub fn repos_base_dir() -> Utf8PathBuf {
         .as_ref()
         .expect("REPOS_BASE_DIR 尚未设置值")
         .clone()
+}
+
+/// Cache redb manipulation.
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "db")]
+struct ArgsDb {
+    /// this should be called before all checks start
+    #[argh(switch)]
+    start: bool,
+    /// this should be called after all checks finish
+    #[argh(switch)]
+    done: bool,
+    /// redb file path; this will be created if not exists
+    #[argh(option)]
+    db: Utf8PathBuf,
+}
+
+impl ArgsDb {
+    fn execute(&self) -> Result<()> {
+        let db = Db::new(&self.db)?;
+        if self.start {
+            db.new_check()
+        } else if self.done {
+            db.check_set_complete()
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/src/db/cache/mod.rs
+++ b/src/db/cache/mod.rs
@@ -178,7 +178,7 @@ impl fmt::Debug for CacheValue {
 impl CacheValue {
     pub fn new(resolve: &Resolve, duration_ms: u64, data: Vec<OutputDataInner>) -> Self {
         CacheValue {
-            unix_timestamp_milli: now(),
+            unix_timestamp_milli: os_checker_types::now(),
             cmd: CacheRepoKeyCmd::new(resolve),
             diagnostics: OutputData { duration_ms, data },
         }
@@ -225,10 +225,4 @@ impl CacheValue {
     pub fn to_db_value(&self) -> out::CacheValue {
         self.clone().into()
     }
-}
-
-/// Returns the current unix timestamp in milliseconds.
-pub fn now() -> u64 {
-    let t = time::OffsetDateTime::from(std::time::SystemTime::now());
-    super::unix_timestamp_milli(t)
 }

--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -135,11 +135,6 @@ impl Db {
         self.check_write_last(|check| check.push_info_key(info))
     }
 
-    // push cache key
-    pub fn check_push_cache_key(&self, cache: CacheRepoKey) -> Result<()> {
-        self.check_write_last(|check| check.push_cache_key(cache))
-    }
-
     // set check complete + merge
     pub fn check_set_complete(&self) -> Result<()> {
         self.check_write_last(|check| check.set_complete())?;

--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -2,9 +2,9 @@ use crate::Result;
 use camino::Utf8Path;
 use eyre::Context;
 use os_checker_types::db::{
-    CacheLayout, CacheRepoKey, CacheValue, Info, InfoKey, DATA, INFO, LAYOUT,
+    CacheLayout, CacheRepoKey, CacheValue, CheckValue, Info, InfoKey, CHECKS, DATA, INFO, LAYOUT,
 };
-use redb::{Database, Key, Table, TableDefinition, Value};
+use redb::{Database, Key, ReadableTable, Table, TableDefinition, Value};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -98,5 +98,73 @@ impl Db {
         } else {
             error!("Unable to get the unique db handler");
         }
+    }
+}
+
+impl Db {
+    fn check_write_last(&self, f: impl FnOnce(&mut CheckValue)) -> Result<()> {
+        self.write(CHECKS, |t| {
+            let (key, mut value) = match t.last()? {
+                Some((guard_k, guard_v)) => (guard_k.value(), guard_v.value()),
+                None => bail!(
+                    "The last check item is not available in {CHECKS}. \
+                     A new check should be created."
+                ),
+            };
+            f(&mut value);
+            t.insert(&key, &value)?;
+            Ok(())
+        })
+    }
+
+    /// Create a new check item only with key set.
+    pub fn new_check(&self) -> Result<()> {
+        self.write(CHECKS, |t| {
+            let key = match t.last()? {
+                Some((guard_k, _)) => guard_k.value() + 1,
+                None => 0,
+            };
+            t.insert(key, &Default::default())?;
+            info!(key, "Successfully create a new check item.");
+            Ok(())
+        })
+    }
+
+    // push info key
+    pub fn check_push_info_key(&self, info: InfoKey) -> Result<()> {
+        self.check_write_last(|check| check.push_info_key(info))
+    }
+
+    // push cache key
+    pub fn check_push_cache_key(&self, cache: CacheRepoKey) -> Result<()> {
+        self.check_write_last(|check| check.push_cache_key(cache))
+    }
+
+    // set check complete + merge
+    pub fn check_set_complete(&self) -> Result<()> {
+        self.check_write_last(|check| check.set_complete())?;
+
+        let txn = self.db.begin_write()?;
+        let mut table = txn.open_table(CHECKS)?;
+
+        let last = table
+            .iter()?
+            .rev()
+            .take(2)
+            .map(|res| res.map(|(k, v)| (k.value(), v.value())))
+            .collect::<Result<Vec<_>, _>>()?;
+        if let [(_, last1_v), (last2_k, last2_v)] = last.as_slice() {
+            if last1_v.is_same_keys(last2_v) {
+                // use the second to last id, and remove the item
+                table.pop_last()?;
+                table.pop_last()?;
+                table.insert(last2_k, last1_v)?;
+            }
+        }
+
+        drop(table);
+        txn.commit()?;
+
+        Ok(())
     }
 }

--- a/src/db/info/mod.rs
+++ b/src/db/info/mod.rs
@@ -196,6 +196,10 @@ impl InfoKeyValue {
     pub fn set_layout_cache(&self, layout: CacheLayout, db: &Db) -> Result<()> {
         db.set_layout(&self.key.to_db_key(), &layout)
     }
+
+    pub fn check_push_info_key(&self, db: &Db) -> Result<()> {
+        db.check_push_info_key(self.key.clone().into())
+    }
 }
 
 #[test]

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -233,6 +233,8 @@ impl RepoOutput {
         outputs.sort_by_name_and_checkers();
         if let Some(db) = repo.config.db() {
             info.set_complete(db)?;
+            // push check item if caching is done
+            info.check_push_info_key(db)?;
             info!("已设置键缓存 complete 为 true");
         }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -189,9 +189,6 @@ impl RepoOutput {
         .entered();
 
         let info = config.new_info()?;
-        if let Some(db) = config.db() {
-            info.check_push_info_key(db)?;
-        }
 
         if utils::force_repo_check() {
             warn!("强制运行检查（不影响已有的检查缓存结果）");
@@ -202,6 +199,9 @@ impl RepoOutput {
                         info!("成功获取完整的仓库检查结果键缓存");
                         match info_cache.get_cache_values(db) {
                             Ok(caches) => {
+                                // push check item if caching is found
+                                info.check_push_info_key(db)?;
+
                                 return Ok(Either::Right(FastOutputs {
                                     config,
                                     outputs: caches.into(),

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -189,6 +189,9 @@ impl RepoOutput {
         .entered();
 
         let info = config.new_info()?;
+        if let Some(db) = config.db() {
+            info.check_push_info_key(db)?;
+        }
 
         if utils::force_repo_check() {
             warn!("强制运行检查（不影响已有的检查缓存结果）");

--- a/src/run_checker/utils.rs
+++ b/src/run_checker/utils.rs
@@ -98,11 +98,6 @@ impl<'a> DbRepo<'a> {
         if let Err(err) = self.info.append_cache_key(key, self.db) {
             error!(%err, ?key, "Unable to save the info cache.");
         }
-
-        // 写入 checks 表
-        if let Err(err) = self.db.check_push_cache_key(key.clone().into()) {
-            error!(%err, ?key, "Unable to push cache key to checks table.");
-        }
     }
 
     /// 写入 layout 缓存

--- a/src/run_checker/utils.rs
+++ b/src/run_checker/utils.rs
@@ -98,6 +98,11 @@ impl<'a> DbRepo<'a> {
         if let Err(err) = self.info.append_cache_key(key, self.db) {
             error!(%err, ?key, "Unable to save the info cache.");
         }
+
+        // 写入 checks 表
+        if let Err(err) = self.db.check_push_cache_key(key.clone().into()) {
+            error!(%err, ?key, "Unable to push cache key to checks table.");
+        }
     }
 
     /// 写入 layout 缓存


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/117

* 通过 db 子命令和 --start 和 --done 参数来控制每组检查的开始和结束，从而解决了分批检查识别首尾的问题；
* 添加 CHECKS 表，其中键为从 0 递增的 u32 值，值为这组检查的仓库的 InfoKey —— 可由这个值，去 INFO 表找到相应的检查命令缓存
* 重构 target 页面生成数据的逻辑