### PR TITLE
feat: 集成 RAP 来检查 Use After Free 和 Memory Leakage 

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,7 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # cache.redb tag in database release
-  TAG_CACHE: cache-v7.redb
+  TAG_CACHE: cache-v8.redb
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,10 +17,10 @@ env:
   # cache.redb tag in database release
   TAG_CACHE: cache-v6.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # use which configs
-  # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  CONFIGS: repos.json # for debug single repo
+  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:
@@ -45,7 +45,7 @@ jobs:
           cp assets/repos-embassy.json ~/check/
           cd ~/check
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
-          # gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb.tar.xz
+          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap cargo-rap # install rap
           # tar -xJvf cache.redb.tar.xz
           ls -alh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,7 +19,7 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # use which configs
   # CONFIGS: repos.json # for debug single repo
   CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
@@ -77,9 +77,11 @@ jobs:
           df -alh
           cd ~/check
           os-checker db --start cache.redb
-          # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+
+          make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
-          batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          # batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+
           os-checker db --done cache.redb
 
       - name: Run cache_redb test

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -94,8 +94,8 @@ jobs:
           cd ~/check
           make clone_database
           cd database
-          # git switch debug
-          # echo "切换到 debug 分支"
+          git switch debug
+          echo "切换到 debug 分支"
           git pull --rebase # 防止二次运行 CI 时落后于远程分支
 
           rm -rf batch # 移除旧的 batch 数据

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -80,9 +80,9 @@ jobs:
           df -alh
           cd ~/check
           os-checker db --start cache.redb
-          # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
-          batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          # batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           os-checker db --done cache.redb
 
       - name: Run cache_redb test
@@ -107,8 +107,8 @@ jobs:
           cd ~/check
           make clone_database
           cd database
-          git switch debug
-          echo "切换到 debug 分支"
+          # git switch debug
+          # echo "切换到 debug 分支"
           git pull --rebase # 防止二次运行 CI 时落后于远程分支
 
           rm -rf batch # 移除旧的 batch 数据

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,14 +15,14 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # cache.redb tag in database release
-  TAG_CACHE: cache-v8.redb
+  TAG_CACHE: cache-v7.redb
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  CONFIGS: repos.json # for debug single repo
-  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  # CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,6 +52,16 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Install checkers
+        run: |
+          # 安装 lockbud，减少源码编译的时间
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/os-checker/lockbud/releases/download/v0.1.0/lockbud-installer.sh | sh
+          # install rap
+          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap 
+          chmod +x rap && mv rap ~/.cargo/bin/
+          chmod +x cargo-rap && mv cargo-rap ~/.cargo/bin/
+          ls -alh ~/.cargo/bin/
+
       - name: Install os-checker
         run: cargo install --path . --force
 
@@ -60,14 +70,6 @@ jobs:
 
       - name: Run All Checkers
         run: |
-          # 安装 lockbud，减少源码编译的时间
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/os-checker/lockbud/releases/download/v0.1.0/lockbud-installer.sh | sh
-          # install rap
-          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap 
-          mv rap ~/.cargo/bin/
-          mv cargo-rap ~/.cargo/bin/
-          ls -alh ~/.cargo/bin/
-          which rap
           git lfs install --skip-smudge # 如果 lfs 下载不了大文件，跳过下载
           df -alh
           cd ~/check

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -48,6 +48,8 @@ jobs:
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap # install rap
           mv rap ~/.cargo/bin/
           mv cargo-rap ~/.cargo/bin/
+          ls -alh ~/.cargo/bin/
+          which rap
           # tar -xJvf cache.redb.tar.xz
           ls -alh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,9 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # cache.redb tag in database release
-  TAG_CACHE: cache-v6.redb
+  TAG_CACHE: cache-v7.redb
+  # compiled checker binaries
+  TAG_CHECKER_DOWNLOAD: cache-v6.redb
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
@@ -31,8 +33,8 @@ jobs:
         with:
             ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: cargo audit
-        run: make audit
+      # - name: cargo audit
+      #   run: make audit
 
       - name: Prepare Makefile and repos JSONs
         run: |
@@ -58,8 +60,10 @@ jobs:
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/os-checker/lockbud/releases/download/v0.1.0/lockbud-installer.sh | sh
           # install mirai
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/os-checker/MIRAI/releases/download/v1.1.9/mirai-installer.sh | sh
+          # install audit
+          gh release download --clobber -R os-checker/database ${{ env.TAG_CHECKER_DOWNLOAD }} -p cargo-audit -D ~/.cargo/bin/
           # install rap
-          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap 
+          gh release download -R os-checker/database ${{ env.TAG_CHECKER_DOWNLOAD }} -p rap -p cargo-rap 
           chmod +x rap && mv rap ~/.cargo/bin/
           chmod +x cargo-rap && mv cargo-rap ~/.cargo/bin/
           ls -alh ~/.cargo/bin/

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -33,9 +33,6 @@ jobs:
         with:
             ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      # - name: cargo audit
-      #   run: make audit
-
       - name: Prepare Makefile and repos JSONs
         run: |
           mkdir -p ~/check/batch
@@ -80,9 +77,9 @@ jobs:
           df -alh
           cd ~/check
           os-checker db --start cache.redb
-          make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
-          # batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           os-checker db --done cache.redb
 
       - name: Run cache_redb test

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,7 +19,7 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v6.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # use which configs
   CONFIGS: repos.json # for debug single repo
   # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,8 +19,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  CONFIGS: repos.json # for debug single repo
-  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  # CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:
@@ -67,9 +67,9 @@ jobs:
           df -alh
           cd ~/check
           os-checker db --start cache.redb
-          make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
-          # batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           os-checker db --done cache.redb
 
       - name: Run cache_redb test

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,10 +19,10 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v6.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # use which configs
-  CONFIGS: repos-ui.json # for debug single repo
-  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  # CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,7 @@ env:
   # cache.redb tag in database release
   TAG_CACHE: cache-v8.redb
   # compiled checker binaries
-  TAG_CHECKER_DOWNLOAD: cache-v6.redb
+  TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -46,8 +46,8 @@ jobs:
           cd ~/check
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap # install rap
-          mv rap ~/.cargo/bin
-          mv cargo-rap ~/.cargo/bin
+          mv rap ~/.cargo/bin/
+          mv cargo-rap ~/.cargo/bin/
           # tar -xJvf cache.redb.tar.xz
           ls -alh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -105,11 +105,11 @@ jobs:
 
           cd ~/check
           make clone_database
+          cd database
 
-          # cd database
           # git switch debug
+          # echo "切换到 debug 分支"
 
-          echo "切换到 debug 分支"
           git pull --rebase # 防止二次运行 CI 时落后于远程分支
 
           rm -rf batch # 移除旧的 batch 数据

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -21,8 +21,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
-  # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  CONFIGS: repos.json # for debug single repo
+  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:
@@ -107,8 +107,8 @@ jobs:
           cd ~/check
           make clone_database
           cd database
-          # git switch debug
-          # echo "切换到 debug 分支"
+          git switch debug
+          echo "切换到 debug 分支"
           git pull --rebase # 防止二次运行 CI 时落后于远程分支
 
           rm -rf batch # 移除旧的 batch 数据

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,8 +19,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  CONFIGS: repos.json # for debug single repo
-  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  # CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -45,11 +45,6 @@ jobs:
           cp assets/repos-embassy.json ~/check/
           cd ~/check
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
-          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap # install rap
-          mv rap ~/.cargo/bin/
-          mv cargo-rap ~/.cargo/bin/
-          ls -alh ~/.cargo/bin/
-          which rap
           # tar -xJvf cache.redb.tar.xz
           ls -alh
 
@@ -67,6 +62,12 @@ jobs:
         run: |
           # 安装 lockbud，减少源码编译的时间
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/os-checker/lockbud/releases/download/v0.1.0/lockbud-installer.sh | sh
+          # install rap
+          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap 
+          mv rap ~/.cargo/bin/
+          mv cargo-rap ~/.cargo/bin/
+          ls -alh ~/.cargo/bin/
+          which rap
           git lfs install --skip-smudge # 如果 lfs 下载不了大文件，跳过下载
           df -alh
           cd ~/check

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -46,6 +46,8 @@ jobs:
           cd ~/check
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap # install rap
+          mv rap ~/.cargo/bin
+          mv cargo-rap ~/.cargo/bin
           # tar -xJvf cache.redb.tar.xz
           ls -alh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -21,7 +21,7 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-ui.json # for debug single repo
   # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,8 +19,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
+  CONFIGS: repos.json # for debug single repo
+  # CONFIGS: repos-default.json repos-ui.json repos-embassy.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,10 +52,12 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install checkers
+      - name: Install Checkers
         run: |
-          # 安装 lockbud，减少源码编译的时间
+          # install lockbud 
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/os-checker/lockbud/releases/download/v0.1.0/lockbud-installer.sh | sh
+          # install mirai
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/os-checker/MIRAI/releases/download/v1.1.9/mirai-installer.sh | sh
           # install rap
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap 
           chmod +x rap && mv rap ~/.cargo/bin/

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -45,7 +45,7 @@ jobs:
           cp assets/repos-embassy.json ~/check/
           cd ~/check
           gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p cache.redb || echo "cache.redb not found"
-          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap cargo-rap # install rap
+          gh release download -R os-checker/database ${{ env.TAG_CACHE }} -p rap -p cargo-rap # install rap
           # tar -xJvf cache.redb.tar.xz
           ls -alh
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,7 @@ env:
   # cache.redb tag in database release
   TAG_CACHE: cache-v8.redb
   # compiled checker binaries
-  TAG_CHECKER_DOWNLOAD: cache-v7.redb
+  TAG_CHECKER_DOWNLOAD: cache-v6.redb
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -105,8 +105,10 @@ jobs:
 
           cd ~/check
           make clone_database
-          cd database
-          git switch debug
+
+          # cd database
+          # git switch debug
+
           echo "切换到 debug 分支"
           git pull --rebase # 防止二次运行 CI 时落后于远程分支
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,7 @@ env:
   # cache.redb tag in database release
   TAG_CACHE: cache-v7.redb
   # compiled checker binaries
-  TAG_CHECKER_DOWNLOAD: cache-v6.redb
+  TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ upload:
 	XZ_OPT=-e9 tar -cJvf cache.redb.tar.xz cache.redb
 	ls -alh
 	gh release upload --clobber -R os-checker/database $(TAG_CACHE) cache.redb.tar.xz
-	gh release upload --clobber -R os-checker/database $(TAG_CACHE) ~/.cargo/os-checker
+	# gh release upload --clobber -R os-checker/database $(TAG_CACHE) ~/.cargo/os-checker
 
 run:
 	@os-checker run $(ARGS_CONFIGS) --emit $(SINGLE_JSON) --db cache.redb

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ upload:
 	XZ_OPT=-e9 tar -cJvf cache.redb.tar.xz cache.redb
 	ls -alh
 	gh release upload --clobber -R os-checker/database $(TAG_CACHE) cache.redb.tar.xz
-	cp ~/.cargo/os-checker os-checker
-	gh release upload --clobber -R os-checker/database $(TAG_CACHE) os-checker
+	gh release upload --clobber -R os-checker/database $(TAG_CACHE) ~/.cargo/bin/os-checker
 
 run:
 	@os-checker run $(ARGS_CONFIGS) --emit $(SINGLE_JSON) --db cache.redb

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ upload:
 	XZ_OPT=-e9 tar -cJvf cache.redb.tar.xz cache.redb
 	ls -alh
 	gh release upload --clobber -R os-checker/database $(TAG_CACHE) cache.redb.tar.xz
-	# gh release upload --clobber -R os-checker/database $(TAG_CACHE) ~/.cargo/os-checker
+	cp ~/.cargo/os-checker os-checker
+	gh release upload --clobber -R os-checker/database $(TAG_CACHE) os-checker
 
 run:
 	@os-checker run $(ARGS_CONFIGS) --emit $(SINGLE_JSON) --db cache.redb

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ upload:
 	XZ_OPT=-e9 tar -cJvf cache.redb.tar.xz cache.redb
 	ls -alh
 	gh release upload --clobber -R os-checker/database $(TAG_CACHE) cache.redb.tar.xz
+	gh release upload --clobber -R os-checker/database $(TAG_CACHE) ~/.cargo/os-checker
 
 run:
 	@os-checker run $(ARGS_CONFIGS) --emit $(SINGLE_JSON) --db cache.redb

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,3 @@
 {
-  "os-checker-test-suite": {}
+  "os-checker/os-checker-test-suite": {}
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,3 @@
 {
-  "arceos-org/arceos": {}
+  "os-checker-test-suite": {}
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,4 +1,3 @@
 {
-  "os-checker/os-checker-test-suite": {},
-  "arceos-usb/arceos_experiment": {}
+  "os-checker/os-checker-test-suite": {}
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,4 @@
 {
-  "os-checker/os-checker-test-suite": {}
+  "os-checker/os-checker-test-suite": {},
+  "kern-crates/rboot": {}
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,6 +1,4 @@
 {
   "os-checker/os-checker-test-suite": {},
-  "kern-crates/rboot": {
-    "no_install_targets": "x86_64-unknown-uefi"
-  }
+  "kern-crates/rvfs": {}
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,4 +1,6 @@
 {
   "os-checker/os-checker-test-suite": {},
-  "kern-crates/rboot": {}
+  "kern-crates/rboot": {
+    "no_install_targets": "x86_64-unknown-uefi"
+  }
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,4 @@
 {
-  "os-checker/os-checker-test-suite": {}
+  "os-checker/os-checker-test-suite": {},
+  "arceos-usb/arceos_experiment": {}
 }

--- a/os-checker-types/src/lib.rs
+++ b/os-checker-types/src/lib.rs
@@ -139,6 +139,7 @@ pub enum Kind {
     LockbudProbably,
     #[serde(rename = "Lockbud(Possibly)")]
     LockbudPossibly,
+    Rap,
     Cargo,
 }
 
@@ -155,6 +156,7 @@ impl Kind {
             Kind::Mirai => "Mirai",
             Kind::LockbudProbably => "Lockbud(Probably)",
             Kind::LockbudPossibly => "Lockbud(Possibly)",
+            Kind::Rap => "Rap",
             Kind::Cargo => "Cargo",
         }
     }
@@ -179,5 +181,6 @@ pub enum CheckerTool {
     Audit,
     Mirai,
     Lockbud,
+    Rap,
     Fmt,
 }

--- a/src/config/checker.rs
+++ b/src/config/checker.rs
@@ -28,6 +28,7 @@ pub enum CheckerTool {
     Audit,
     Mirai,
     Lockbud,
+    Rap,
     /// 这是一个虚拟的检查工具，它表示 stderr 中含 `^error:` 的情况
     Cargo,
 }
@@ -43,6 +44,7 @@ impl CheckerTool {
             CheckerTool::Audit => "audit",
             CheckerTool::Mirai => "mirai",
             CheckerTool::Lockbud => "lockbud",
+            CheckerTool::Rap => "rap",
             CheckerTool::Cargo => "cargo",
         }
     }

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -2,7 +2,7 @@ use crate::{
     config::{CheckerTool, Resolve},
     layout::Pkg,
     output::host_toolchain,
-    utils::{PLUS_TOOLCHAIN_LOCKBUD, PLUS_TOOLCHAIN_MIRAI},
+    utils::{PLUS_TOOLCHAIN_LOCKBUD, PLUS_TOOLCHAIN_MIRAI, PLUS_TOOLCHAIN_RAP},
     Result,
 };
 use duct::cmd;
@@ -90,6 +90,44 @@ pub fn cargo_mirai(pkg: &Pkg) -> Resolve {
     debug!(?expr);
     let cmd = format!("cargo {PLUS_TOOLCHAIN_MIRAI} mirai --target {target} --message-format=json");
     Resolve::new(pkg, CheckerTool::Mirai, cmd, expr)
+}
+
+/// 运行 cargo rap 检查 use after free 的命令
+pub fn cargo_rap_uaf(pkg: &Pkg) -> Resolve {
+    // let target = pkg.target;
+
+    let expr = cmd!(
+        "cargo",
+        PLUS_TOOLCHAIN_RAP,
+        "rap",
+        "-F" // -F -M 尚不同时支持；也不支持指定 --target
+             // "--target",
+             // target,
+    )
+    .env("RAP_LOG", "WARN")
+    .dir(pkg.dir);
+    debug!(?expr);
+    let cmd = format!("cargo {PLUS_TOOLCHAIN_RAP} rap -F");
+    Resolve::new(pkg, CheckerTool::Rap, cmd, expr)
+}
+
+/// 运行 cargo rap 检查 memory leak 的命令
+pub fn cargo_rap_memoryleak(pkg: &Pkg) -> Resolve {
+    // let target = pkg.target;
+
+    let expr = cmd!(
+        "cargo",
+        PLUS_TOOLCHAIN_RAP,
+        "rap",
+        "-M" // -F -M 尚不同时支持；也不支持指定 --target
+             // "--target",
+             // target,
+    )
+    .env("RAP_LOG", "WARN")
+    .dir(pkg.dir);
+    debug!(?expr);
+    let cmd = format!("cargo {PLUS_TOOLCHAIN_RAP} rap -M");
+    Resolve::new(pkg, CheckerTool::Rap, cmd, expr)
 }
 
 /// 自定义检查命令。

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -195,6 +195,7 @@ fn resolve_for_single_pkg(cmds: &Cmds, pkgs: &[Pkg], v: &mut Vec<Resolve>) -> Re
             (Lockbud, Left(true)) => Resolve::lockbud(pkgs, v),
             (Mirai, Left(true)) => Resolve::mirai(pkgs, v),
             (Audit, Left(true)) => Resolve::audit(pkgs, v),
+            (Rap, Left(true)) => Resolve::rap(pkgs, v),
             (c, Right(s)) => Resolve::custom(pkgs, s, c, v)?,
             _ => (),
         }

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -122,13 +122,14 @@ impl Cmds {
                 Lockbud => ENABLED,
                 Mirai => ENABLED,
                 Audit => ENABLED,
+                Rap => ENABLED,
             },
         }
     }
 
     /// TODO: 其他工具待完成
     pub fn enable_all_checkers(&mut self) {
-        for checker in [Fmt, Clippy, Lockbud, Mirai, Audit] {
+        for checker in [Fmt, Clippy, Lockbud, Mirai, Audit, Rap] {
             self.entry(checker)
                 .and_modify(|cmd| *cmd = ENABLED)
                 .or_insert(ENABLED);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,8 +9,7 @@ use itertools::Itertools;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use serde_json::Value;
 
-mod cmd;
-use cmd::*;
+pub mod cmd;
 
 mod resolve;
 pub use resolve::Resolve;

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -6,7 +6,7 @@
 //!     * 如果指定包名，则校验是否定义于仓库内：需要 repo layout 信息
 //!     * 如果指定 features，则校验是否定义于 package 内：需要 cargo metadata 信息
 
-use super::{cargo_clippy, cargo_fmt, cargo_lockbud, cargo_mirai, checker::CheckerTool, custom};
+use super::{cmd::*, CheckerTool};
 use crate::{
     layout::{Audit, Pkg},
     output::{get_toolchain, host_target_triple},
@@ -131,6 +131,14 @@ impl Resolve {
                 val.audit = Some(audit.clone());
                 resolved.push(val);
             }
+        }
+    }
+
+    pub fn rap(pkgs: &[Pkg], resolved: &mut Vec<Self>) {
+        resolved.reserve(pkgs.len() * 2);
+        for pkg in pkgs {
+            resolved.push(cargo_rap_uaf(pkg));
+            resolved.push(cargo_rap_memoryleak(pkg));
         }
     }
 

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -144,6 +144,11 @@ impl Resolve {
         }
     }
 
+    /// force checking even if a cache exists
+    pub fn force_check(&self) -> bool {
+        matches!(self.checker, CheckerTool::Rap)
+    }
+
     #[instrument(level = "trace")]
     pub fn custom(
         pkgs: &[Pkg],

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -176,4 +176,22 @@ impl Resolve {
         // 0 表示 host toolchain
         get_toolchain(self.toolchain.unwrap_or(0))
     }
+
+    /// Some diagnostics are hard/impossible to know the source, so paste these useful info to them.
+    pub fn display(&self) -> String {
+        let Self {
+            pkg_name,
+            pkg_dir,
+            target,
+            checker,
+            cmd,
+            ..
+        } = self;
+        let toolchain = self.toolchain();
+        format!(
+            "pkg={pkg_name}, checker={checker:?}\n\
+            toolchain={toolchain}, target={target}\n\
+            pkg_dir={pkg_dir}\ncmd={cmd}",
+        )
+    }
 }

--- a/src/db/cache/type_conversion.rs
+++ b/src/db/cache/type_conversion.rs
@@ -124,6 +124,7 @@ impl From<CheckerTool> for os_checker_types::CheckerTool {
             CheckerTool::Audit => Self::Audit,
             CheckerTool::Mirai => Self::Mirai,
             CheckerTool::Lockbud => Self::Lockbud,
+            CheckerTool::Rap => Self::Rap,
             CheckerTool::Cargo => Self::Cargo,
         }
     }
@@ -141,6 +142,7 @@ impl From<Kind> for os_checker_types::Kind {
             Kind::Mirai => Self::Mirai,
             Kind::LockbudProbably => Self::LockbudProbably,
             Kind::LockbudPossibly => Self::LockbudPossibly,
+            Kind::Rap => Self::Rap,
             Kind::Cargo => Self::Cargo,
         }
     }
@@ -265,6 +267,7 @@ impl From<os_checker_types::CheckerTool> for CheckerTool {
             os_checker_types::CheckerTool::Audit => Self::Audit,
             os_checker_types::CheckerTool::Mirai => Self::Mirai,
             os_checker_types::CheckerTool::Lockbud => Self::Lockbud,
+            os_checker_types::CheckerTool::Rap => Self::Rap,
             os_checker_types::CheckerTool::Cargo => Self::Cargo,
         }
     }
@@ -282,6 +285,7 @@ impl From<os_checker_types::Kind> for Kind {
             os_checker_types::Kind::Mirai => Self::Mirai,
             os_checker_types::Kind::LockbudProbably => Self::LockbudProbably,
             os_checker_types::Kind::LockbudPossibly => Self::LockbudPossibly,
+            os_checker_types::Kind::Rap => Self::Rap,
             os_checker_types::Kind::Cargo => Self::Cargo,
         }
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -201,6 +201,7 @@ impl Kinds {
                 ClippyWarn,
                 Audit,
                 Mirai,
+                Rap,
                 LockbudProbably,
                 LockbudPossibly,
                 Unformatted,
@@ -210,6 +211,7 @@ impl Kinds {
                 "clippy": [ClippyError, ClippyWarn],
                 "audit": [Audit],
                 "mirai": [Mirai],
+                "rap": [Rap],
                 "lockbud": [LockbudProbably, LockbudPossibly],
                 "fmt": [Unformatted]
             }),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -180,6 +180,7 @@ pub enum Kind {
     LockbudProbably,
     #[serde(rename = "Lockbud(Possibly)")]
     LockbudPossibly,
+    Rap,
     Cargo,
 }
 

--- a/src/run_checker/lockbud.rs
+++ b/src/run_checker/lockbud.rs
@@ -2,7 +2,8 @@ use super::CargoMessage;
 
 #[cfg(test)]
 pub fn get_lockbud_result() -> crate::Result<String> {
-    let out = duct::cmd!("cargo", "+nightly-2024-05-21", "lockbud", "-k", "all")
+    let toolchain = crate::utils::PLUS_TOOLCHAIN_LOCKBUD;
+    let out = duct::cmd!("cargo", toolchain, "lockbud", "-k", "all")
         .dir("repos/os-checker-test-suite")
         .stderr_capture()
         .run()?;

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -388,6 +388,7 @@ fn run_check(
                 .collect::<Result<_>>()?,
         ),
         CheckerTool::Lockbud => OutputParsed::Lockbud(lockbud::parse_lockbud_result(&raw.stderr)),
+        CheckerTool::Rap => todo!(),
         CheckerTool::Miri => todo!(),
         CheckerTool::Audit => OutputParsed::Audit(resolve.audit.clone()),
         CheckerTool::SemverChecks => todo!(),

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -328,7 +328,9 @@ fn run_check(
     db_repo: Option<DbRepo>,
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
+    // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
     if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
+        // if outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -392,7 +392,7 @@ fn run_check(
                 .collect::<Result<_>>()?,
         ),
         CheckerTool::Lockbud => OutputParsed::Lockbud(lockbud::parse_lockbud_result(&raw.stderr)),
-        CheckerTool::Rap => OutputParsed::Rap(rap::parse_rap_result(&raw.stderr)),
+        CheckerTool::Rap => OutputParsed::Rap(rap::rap_output(&raw.stderr, &resolve)),
         CheckerTool::Miri => todo!(),
         CheckerTool::Audit => OutputParsed::Audit(resolve.audit.clone()),
         CheckerTool::SemverChecks => todo!(),

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -328,7 +328,7 @@ fn run_check(
     db_repo: Option<DbRepo>,
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
-    if outputs.fetch_cache(&resolve, db_repo) {
+    if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -329,8 +329,8 @@ fn run_check(
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
     // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
-    if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
-        // if outputs.fetch_cache(&resolve, db_repo) {
+    // if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
+    if outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -11,7 +11,7 @@ pub fn parse_rap_result(stderr: &[u8]) -> String {
             _ = writeln!(&mut rap_output, "{line}");
         }
     }
-    info!(rap_output, ?stderr);
+    // info!(rap_output, ?stderr);
     rap_output
 }
 

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -1,0 +1,18 @@
+use std::io::Write;
+
+/// See https://github.com/Artisan-Lab/RAP/issues/53
+pub fn parse_rap_result(stderr: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr);
+    let mut writer = strip_ansi_escapes::Writer::new(Vec::with_capacity(stderr.len() / 2));
+
+    for line in stderr.lines() {
+        if line.contains("RAP-FRONT|WARN") {
+            if let Err(err) = writer.write_all(line.as_bytes()) {
+                error!(line, ?err, "strip_ansi_escapes for rap output");
+            }
+        }
+    }
+    _ = writer.flush();
+    let bytes = writer.into_inner().unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -11,7 +11,7 @@ pub fn parse_rap_result(stderr: &[u8]) -> String {
             _ = writeln!(&mut rap_output, "{line}");
         }
     }
-    // info!(rap_output, ?stderr);
+    info!(rap_output, ?stderr);
     rap_output
 }
 

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -16,7 +16,7 @@ pub fn parse_rap_result(stderr: &[u8]) -> String {
     _ = writer.flush();
     let bytes = writer.into_inner().unwrap();
     let rap_output = String::from_utf8_lossy(&bytes).into_owned();
-    info!(rap_output);
+    info!(rap_output, ?stderr);
     rap_output
 }
 

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -2,7 +2,8 @@ use std::io::Write;
 
 /// See https://github.com/Artisan-Lab/RAP/issues/53
 pub fn parse_rap_result(stderr: &[u8]) -> String {
-    let stderr = String::from_utf8_lossy(stderr);
+    // rap doesn't provide no-color option
+    let stderr = String::from_utf8(strip_ansi_escapes::strip(stderr)).unwrap();
     let mut writer = strip_ansi_escapes::Writer::new(Vec::with_capacity(stderr.len() / 2));
 
     for line in stderr.lines() {

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -7,7 +7,7 @@ pub fn parse_rap_result(stderr: &[u8]) -> String {
     let mut rap_output = String::with_capacity(stderr.len() / 2);
 
     for line in stderr.lines() {
-        if line.contains("RAP-FRONT|WARN") {
+        if line.contains("RAP|WARN") {
             _ = writeln!(&mut rap_output, "{line}");
         }
     }

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -1,22 +1,16 @@
-use std::io::Write;
+use std::fmt::Write;
 
 /// See https://github.com/Artisan-Lab/RAP/issues/53
 pub fn parse_rap_result(stderr: &[u8]) -> String {
     // rap doesn't provide no-color option
     let stderr = String::from_utf8(strip_ansi_escapes::strip(stderr)).unwrap();
-    let mut writer = strip_ansi_escapes::Writer::new(Vec::with_capacity(stderr.len() / 2));
+    let mut rap_output = String::with_capacity(stderr.len() / 2);
 
     for line in stderr.lines() {
         if line.contains("RAP-FRONT|WARN") {
-            match writer.write_all(line.as_bytes()) {
-                Ok(_) => _ = writer.write(b"\n"),
-                Err(err) => error!(line, ?err, "strip_ansi_escapes for rap output"),
-            }
+            _ = writeln!(&mut rap_output, "{line}");
         }
     }
-    _ = writer.flush();
-    let bytes = writer.into_inner().unwrap();
-    let rap_output = String::from_utf8_lossy(&bytes).into_owned();
     info!(rap_output, ?stderr);
     rap_output
 }

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -15,7 +15,9 @@ pub fn parse_rap_result(stderr: &[u8]) -> String {
     }
     _ = writer.flush();
     let bytes = writer.into_inner().unwrap();
-    String::from_utf8_lossy(&bytes).into_owned()
+    let rap_output = String::from_utf8_lossy(&bytes).into_owned();
+    info!(rap_output);
+    rap_output
 }
 
 #[test]

--- a/src/run_checker/rap.rs
+++ b/src/run_checker/rap.rs
@@ -1,7 +1,16 @@
+use crate::config::Resolve;
 use std::fmt::Write;
 
+pub fn rap_output(stderr: &[u8], resolve: &Resolve) -> String {
+    let mut output = parse_rap_result(stderr);
+    if !output.is_empty() {
+        output.insert_str(0, &resolve.display());
+    }
+    output
+}
+
 /// See https://github.com/Artisan-Lab/RAP/issues/53
-pub fn parse_rap_result(stderr: &[u8]) -> String {
+fn parse_rap_result(stderr: &[u8]) -> String {
     // rap doesn't provide no-color option
     let stderr = String::from_utf8(strip_ansi_escapes::strip(stderr)).unwrap();
     let mut rap_output = String::with_capacity(stderr.len() / 2);

--- a/src/run_checker/utils.rs
+++ b/src/run_checker/utils.rs
@@ -51,6 +51,7 @@ impl RawOutput {
             OutputParsed::Audit(a) => data_audit(a, root),
             OutputParsed::Mirai(v) => data_rustc(CheckerTool::Mirai, v, root),
             OutputParsed::Lockbud(s) => data_lockbud(s),
+            OutputParsed::Rap(s) => data_rap(s),
             OutputParsed::Cargo { source, stderr } => data_cargo(source, stderr),
         };
 
@@ -129,7 +130,25 @@ fn data_lockbud(s: &str) -> Vec<OutputDataInner> {
         } else {
             Kind::LockbudProbably
         };
-        let data = OutputDataInner::new("Not supported to display yet.".into(), kind, s.to_owned());
+        let data = OutputDataInner::new(
+            "[lockbud] Not supported to display yet.".into(),
+            kind,
+            s.to_owned(),
+        );
+        vec![data]
+    }
+}
+
+fn data_rap(s: &str) -> Vec<OutputDataInner> {
+    if s.is_empty() {
+        Vec::new()
+    } else {
+        // FIXME: 目前 rap 无法良好地解析，需要等它实现 JSON 输出才能更可靠地区分哪种
+        let data = OutputDataInner::new(
+            "[rap] Not supported to display yet.".into(),
+            Kind::Rap,
+            s.to_owned(),
+        );
         vec![data]
     }
 }

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -1,6 +1,6 @@
 use super::{
     git_clone, BASE_DIR_CHECKERS, PLUS_TOOLCHAIN_HOST, PLUS_TOOLCHAIN_LOCKBUD,
-    PLUS_TOOLCHAIN_MIRAI, TOOLCHAIN_LOCKBUD,
+    PLUS_TOOLCHAIN_MIRAI, TOOLCHAIN_LOCKBUD, TOOLCHAIN_RAP,
 };
 use crate::{utils::TOOLCHAIN_MIRAI, Result};
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
@@ -132,6 +132,7 @@ fn check_or_install_checkers() -> Result<()> {
 
     install("lockbud", TOOLCHAIN_LOCKBUD, setup_lockbud)?;
     install("mirai", TOOLCHAIN_MIRAI, setup_mirai)?;
+    install_checker_toolchain("rap", TOOLCHAIN_RAP)?;
 
     Ok(())
 }

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -132,7 +132,9 @@ fn check_or_install_checkers() -> Result<()> {
 
     install("lockbud", TOOLCHAIN_LOCKBUD, setup_lockbud)?;
     install("mirai", TOOLCHAIN_MIRAI, setup_mirai)?;
-    install_checker_toolchain("rap", TOOLCHAIN_RAP)?;
+    install("rap", TOOLCHAIN_RAP, || {
+        bail!("Rap should be installed manually for now.")
+    })?;
 
     Ok(())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -25,6 +25,9 @@ pub const PLUS_TOOLCHAIN_LOCKBUD: &str = "+nightly-2024-05-21";
 pub const TOOLCHAIN_MIRAI: &str = "nightly-2023-12-30";
 pub const PLUS_TOOLCHAIN_MIRAI: &str = "+nightly-2023-12-30";
 
+pub const TOOLCHAIN_RAP: &str = "nightly-2024-06-30";
+pub const PLUS_TOOLCHAIN_RAP: &str = "+nightly-2024-06-30";
+
 /// git clone 一个仓库到一个 dir。
 /// 如果该仓库已存在，则 git pull 拉取最新的代码。
 #[instrument(level = "trace")]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,6 +18,9 @@ pub const BASE_DIR_CHECKERS: &str = "/tmp/os-checker/checkers";
 /// 特殊的编译目标，os-checker 目前不支持在这上面运行检查。
 pub const PECULIAR_TARGETS: &[&str] = &["x86_64-fuchsia", "avr-unknown-gnu-atmega328"];
 
+/// 本机工具链（目前假设 CI 的运行平台）
+pub const HOST_TARGET: &str = "x86_64-unknown-linux-gnu";
+
 /// 检查工具固定的工具链
 pub const PLUS_TOOLCHAIN_HOST: &str = "+nightly";
 pub const TOOLCHAIN_LOCKBUD: &str = "nightly-2024-05-21";


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/138

![截图_20241019194921](https://github.com/user-attachments/assets/02ea1b7f-2a9f-47fb-be6e-6e82817d88f8)
![](https://github.com/user-attachments/assets/cbdea3b2-b9ba-43ec-8977-aad1f58181c5)

遗留问题：
* 和 lockbud 一样，诊断采用不可解析的日志形式输出，导致结果呈现不友好，并且无法精确到文件
* 目前只在 host target 上运行检查，因为 RAP 暂不支持转发 cargo check 参数
* -F 和 -M 两类检查目前必须是分开成 rap 两个命令，加上每次检查需要 cargo clean，这导致检查时间翻倍