### PR TITLE
feat: 集成 cargo-geiger 来检测代码库中是否包含 unsafe Rust

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -71,11 +71,14 @@ jobs:
           gh release download -R os-checker/database ${{ env.TAG_CHECKER_DOWNLOAD }} -p rap -p cargo-rap 
           chmod +x rap && mv rap ~/.cargo/bin/
           chmod +x cargo-rap && mv cargo-rap ~/.cargo/bin/
-          ls -alh ~/.cargo/bin/
           # install outdated
           wget https://github.com/kbknapp/cargo-outdated/releases/download/v0.15.0/cargo-outdated-0.15.0-x86_64-unknown-linux-musl.tar.gz
           tar xvzf cargo-outdated-0.15.0-x86_64-unknown-linux-musl.tar.gz
           mv cargo-outdated ~/.cargo/bin/
+          # install audit
+          gh release download --clobber -R os-checker/database ${{ env.TAG_CHECKER_DOWNLOAD }} -p cargo-geiger -D ~/.cargo/bin/
+          chmod +x ~/.cargo/bin/cargo-geiger
+          ls -alh ~/.cargo/bin/
 
       - name: Install os-checker
         run: cargo install --path . --force

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,7 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # push to which database branch 
-  DATABASE: main
+  DATABASE: debug
   # cache.redb tag in database release
   TAG_CACHE: cache-v9.redb
   # repos-default.json tag in database release

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,7 +23,7 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # use which configs
   # CONFIGS: repos.json # for debug single repo
   CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,10 +23,10 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # use which configs
-  # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json # full repo list
+  CONFIGS: repos.json # for debug single repo
+  # CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,7 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # push to which database branch 
-  DATABASE: debug
+  DATABASE: main
   # cache.redb tag in database release
   TAG_CACHE: cache-v9.redb
   # repos-default.json tag in database release
@@ -23,7 +23,7 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # use which configs
   # CONFIGS: repos.json # for debug single repo
   CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,7 @@ env:
   # push to which database branch 
   DATABASE: debug
   # cache.redb tag in database release
-  TAG_CACHE: cache-v10.redb
+  TAG_CACHE: cache-v9.redb
   # repos-default.json tag in database release
   TAG_CACHE_REPOS_DEFAULT: cache-v8.redb
   # compiled checker binaries

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,8 +25,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  CONFIGS: repos.json # for debug single repo
-  # CONFIGS: repos-default.json repos-ui.json # full repo list
+  # CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:
@@ -93,9 +93,9 @@ jobs:
           cd ~/check
           os-checker db --start cache.redb
 
-          make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
-          # batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          batch --size 8 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
 
           os-checker db --done cache.redb
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,7 +26,7 @@ env:
   FORCE_REPO_CHECK: false
   # use which configs
   # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json # full repo list
+  CONFIGS: repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,7 @@ env:
   # push to which database branch 
   DATABASE: debug
   # cache.redb tag in database release
-  TAG_CACHE: cache-v9.redb
+  TAG_CACHE: cache-v10.redb
   # repos-default.json tag in database release
   TAG_CACHE_REPOS_DEFAULT: cache-v8.redb
   # compiled checker binaries

--- a/assets/repos-ui.json
+++ b/assets/repos-ui.json
@@ -48,6 +48,9 @@
         "examples/**",
         "tests/**"
       ]
+    },
+    "cmds": {
+      "mirai": false
     }
   },
   "kern-crates/rust-sel4": {

--- a/assets/repos-ui.json
+++ b/assets/repos-ui.json
@@ -41,18 +41,6 @@
       "mirai": false
     }
   },
-  "AsyncModules/embassy-priority": {
-    "meta": {
-      "skip_pkg_dir_globs": [
-        "docs/**",
-        "examples/**",
-        "tests/**"
-      ]
-    },
-    "cmds": {
-      "mirai": false
-    }
-  },
   "kern-crates/rust-sel4": {
     "meta": {
       "skip_pkg_dir_globs": [

--- a/assets/repos-ui.json
+++ b/assets/repos-ui.json
@@ -1,26 +1,4 @@
 {
-  "arceos-org/arceos": {
-    "packages": {
-      "bwbench-client": {
-        "targets": "x86_64-unknown-linux-gnu"
-      },
-      "deptool": {
-        "targets": "x86_64-unknown-linux-gnu"
-      },
-      "arceos-shell": {
-        "targets": "x86_64-unknown-linux-gnu"
-      },
-      "arceos-httpserver": {
-        "targets": "x86_64-unknown-linux-gnu"
-      },
-      "arceos-httpclient": {
-        "targets": "x86_64-unknown-linux-gnu"
-      },
-      "arceos-helloworld": {
-        "targets": "x86_64-unknown-linux-gnu"
-      }
-    }
-  },
   "kern-crates/arceos": {
     "packages": {
       "bwbench-client": {

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,1 +1,3 @@
-{}
+{
+  "os-checker/os-checker-test-suite": {}
+}

--- a/os-checker-types/src/lib.rs
+++ b/os-checker-types/src/lib.rs
@@ -141,6 +141,7 @@ pub enum Kind {
     LockbudPossibly,
     Rap,
     Outdated,
+    Geiger,
     Cargo,
 }
 
@@ -159,6 +160,7 @@ impl Kind {
             Kind::LockbudPossibly => "Lockbud(Possibly)",
             Kind::Rap => "Rap",
             Kind::Outdated => "Outdated",
+            Kind::Geiger => "Geiger",
             Kind::Cargo => "Cargo",
         }
     }
@@ -177,13 +179,14 @@ pub struct Kinds {
 pub enum CheckerTool {
     /// 这是一个虚拟的检查工具，它表示 stderr 中含 `^error:` 的情况
     Cargo,
-    Miri,
     Clippy,
+    Miri,
     SemverChecks,
     Audit,
     Mirai,
     Lockbud,
     Rap,
     Outdated,
+    Geiger,
     Fmt,
 }

--- a/src/config/checker.rs
+++ b/src/config/checker.rs
@@ -1,7 +1,8 @@
 use musli::{Decode, Encode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-pub const TOOLS: usize = 6; // 目前支持的检查工具数量
+
+pub const TOOLS: usize = 11; // 目前支持的检查工具数量
 
 /// 检查工具
 #[derive(
@@ -30,6 +31,7 @@ pub enum CheckerTool {
     Lockbud,
     Rap,
     Outdated,
+    Geiger,
     /// 这是一个虚拟的检查工具，它表示 stderr 中含 `^error:` 的情况
     Cargo,
 }
@@ -47,6 +49,7 @@ impl CheckerTool {
             CheckerTool::Lockbud => "lockbud",
             CheckerTool::Rap => "rap",
             CheckerTool::Outdated => "outdated",
+            CheckerTool::Geiger => "geiger",
             CheckerTool::Cargo => "cargo",
         }
     }

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -110,24 +110,14 @@ pub fn cargo_rap(pkg: &Pkg) -> Resolve {
     Resolve::new(pkg, CheckerTool::Rap, cmd, expr)
 }
 
-// /// 运行 cargo rap 检查 memory leak 的命令
-// pub fn cargo_rap_memoryleak(pkg: &Pkg) -> Resolve {
-//     // let target = pkg.target;
-//
-//     let expr = cmd!(
-//         "cargo",
-//         PLUS_TOOLCHAIN_RAP,
-//         "rap",
-//         "-M" // -F -M 尚不同时支持；也不支持指定 --target
-//              // "--target",
-//              // target,
-//     )
-//     .env("RAP_LOG", "WARN")
-//     .dir(pkg.dir);
-//     debug!(?expr);
-//     let cmd = format!("cargo {PLUS_TOOLCHAIN_RAP} rap -M");
-//     Resolve::new(pkg, CheckerTool::Rap, cmd, expr)
-// }
+pub fn cargo_geiger(pkg: &Pkg) -> Resolve {
+    // let target = pkg.target;
+
+    let expr = cmd!("cargo", "geiger", "--output-format", "Ascii").dir(pkg.dir);
+    debug!(?expr);
+    let cmd = "cargo geiger --output-format Ascii".to_owned();
+    Resolve::new(pkg, CheckerTool::Geiger, cmd, expr)
+}
 
 pub fn cargo_outdated(pkg: &Pkg) -> Resolve {
     let expr = cmd!("cargo", "outdated", "-R", "--exit-code=2", "--color=never").dir(pkg.dir);

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -118,7 +118,8 @@ pub fn cargo_geiger(pkg: &Pkg) -> Resolve {
         "geiger",
         "--output-format",
         "Ascii",
-        "--color=never",
+        "--color",
+        "never",
     )
     .dir(pkg.dir);
     debug!(?expr);

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -113,7 +113,14 @@ pub fn cargo_rap(pkg: &Pkg) -> Resolve {
 pub fn cargo_geiger(pkg: &Pkg) -> Resolve {
     // let target = pkg.target;
 
-    let expr = cmd!("cargo", "geiger", "--output-format", "Ascii").dir(pkg.dir);
+    let expr = cmd!(
+        "cargo",
+        "geiger",
+        "--output-format",
+        "Ascii",
+        "--color=never",
+    )
+    .dir(pkg.dir);
     debug!(?expr);
     let cmd = "cargo geiger --output-format Ascii".to_owned();
     Resolve::new(pkg, CheckerTool::Geiger, cmd, expr)

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -203,6 +203,7 @@ fn resolve_for_single_pkg(cmds: &Cmds, pkgs: &[Pkg], v: &mut Vec<Resolve>) -> Re
             (Audit, Left(true)) => Resolve::audit(pkgs, v),
             (Rap, Left(true)) => Resolve::rap(pkgs, v),
             (Outdated, Left(true)) => Resolve::outdated(pkgs, v),
+            (Geiger, Left(true)) => Resolve::geiger(pkgs, v),
             (c, Right(s)) => Resolve::custom(pkgs, s, c, v)?,
             _ => (),
         }

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -125,13 +125,14 @@ impl Cmds {
                 Audit => ENABLED,
                 Rap => ENABLED,
                 Outdated => ENABLED,
+                Geiger => ENABLED,
             },
         }
     }
 
     /// TODO: 其他工具待完成
     pub fn enable_all_checkers(&mut self) {
-        for checker in [Fmt, Clippy, Lockbud, Mirai, Audit, Rap, Outdated] {
+        for checker in [Fmt, Clippy, Lockbud, Mirai, Audit, Rap, Outdated, Geiger] {
             self.entry(checker)
                 .and_modify(|cmd| *cmd = ENABLED)
                 .or_insert(ENABLED);

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -155,7 +155,7 @@ impl Resolve {
 
     /// force checking even if a cache exists
     pub fn force_check(&self) -> bool {
-        matches!(self.checker, CheckerTool::Rap)
+        matches!(self.checker, CheckerTool::Geiger)
     }
 
     pub fn outdated(pkgs: &[Pkg], resolved: &mut Vec<Self>) {

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -143,6 +143,16 @@ impl Resolve {
         }
     }
 
+    pub fn geiger(pkgs: &[Pkg], resolved: &mut Vec<Self>) {
+        resolved.reserve(pkgs.len());
+        for pkg in pkgs {
+            // FIXME: 保险起见暂时只在 x86_64-unknown-linux-gnu 上检查，虽然 geiger 支持条件编译参数
+            if pkg.target == HOST_TARGET {
+                resolved.push(cargo_geiger(pkg));
+            }
+        }
+    }
+
     /// force checking even if a cache exists
     pub fn force_check(&self) -> bool {
         matches!(self.checker, CheckerTool::Rap)

--- a/src/db/cache/type_conversion.rs
+++ b/src/db/cache/type_conversion.rs
@@ -126,6 +126,7 @@ impl From<CheckerTool> for os_checker_types::CheckerTool {
             CheckerTool::Lockbud => Self::Lockbud,
             CheckerTool::Rap => Self::Rap,
             CheckerTool::Outdated => Self::Outdated,
+            CheckerTool::Geiger => Self::Geiger,
             CheckerTool::Cargo => Self::Cargo,
         }
     }
@@ -145,6 +146,7 @@ impl From<Kind> for os_checker_types::Kind {
             Kind::LockbudPossibly => Self::LockbudPossibly,
             Kind::Rap => Self::Rap,
             Kind::Outdated => Self::Outdated,
+            Kind::Geiger => Self::Geiger,
             Kind::Cargo => Self::Cargo,
         }
     }
@@ -271,6 +273,7 @@ impl From<os_checker_types::CheckerTool> for CheckerTool {
             os_checker_types::CheckerTool::Lockbud => Self::Lockbud,
             os_checker_types::CheckerTool::Rap => Self::Rap,
             os_checker_types::CheckerTool::Outdated => Self::Outdated,
+            os_checker_types::CheckerTool::Geiger => Self::Geiger,
             os_checker_types::CheckerTool::Cargo => Self::Cargo,
         }
     }
@@ -290,6 +293,7 @@ impl From<os_checker_types::Kind> for Kind {
             os_checker_types::Kind::LockbudPossibly => Self::LockbudPossibly,
             os_checker_types::Kind::Rap => Self::Rap,
             os_checker_types::Kind::Outdated => Self::Outdated,
+            os_checker_types::Kind::Geiger => Self::Geiger,
             os_checker_types::Kind::Cargo => Self::Cargo,
         }
     }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -182,6 +182,7 @@ pub enum Kind {
     LockbudPossibly,
     Rap,
     Outdated,
+    Geiger,
     Cargo,
 }
 
@@ -206,6 +207,7 @@ impl Kinds {
                 LockbudProbably,
                 LockbudPossibly,
                 Outdated,
+                Geiger,
                 Unformatted,
             ],
             mapping: serde_json::json!({
@@ -216,6 +218,7 @@ impl Kinds {
                 "rap": [Rap],
                 "lockbud": [LockbudProbably, LockbudPossibly],
                 "outdated": [Outdated],
+                "geiger": [Geiger],
                 "fmt": [Unformatted]
             }),
         }

--- a/src/run_checker/geiger.rs
+++ b/src/run_checker/geiger.rs
@@ -1,0 +1,11 @@
+pub fn parse(out: &std::process::Output, resolve: &crate::config::Resolve) -> String {
+    let output = String::from_utf8_lossy(&out.stdout);
+    // cargo-geiger doesn't report via exitcode,
+    // so we have to search by chars.
+    // ! must appear once in the header description
+    if output.matches("! ").nth(1).is_some() {
+        format!("{}{output}", resolve.display())
+    } else {
+        String::new()
+    }
+}

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -396,6 +396,7 @@ fn run_check(
         CheckerTool::Rap => OutputParsed::Rap(rap::rap_output(&raw.stderr, &resolve)),
         CheckerTool::Audit => OutputParsed::Audit(resolve.audit.clone()),
         CheckerTool::Outdated => OutputParsed::Outdated(outdated::parse_outdated(&raw, &resolve)),
+        CheckerTool::Geiger => todo!(),
         CheckerTool::Miri => todo!(),
         CheckerTool::SemverChecks => todo!(),
         // 由于 run_check 只输出单个 Ouput，而其他检查工具可能会利用 cargo，因此导致发出两类诊断

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -331,8 +331,8 @@ fn run_check(
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
     // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
-    if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
-        // if outputs.fetch_cache(&resolve, db_repo) {
+    // if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
+    if outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -331,8 +331,8 @@ fn run_check(
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
     // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
-    // if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
-    if outputs.fetch_cache(&resolve, db_repo) {
+    if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
+        // if outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/run_checker/utils.rs
+++ b/src/run_checker/utils.rs
@@ -53,6 +53,7 @@ impl RawOutput {
             OutputParsed::Lockbud(s) => data_lockbud(s),
             OutputParsed::Rap(s) => data_rap(s),
             OutputParsed::Outdated(s) => data_outdated(s),
+            OutputParsed::Geiger(s) => data_geiger(s),
             OutputParsed::Cargo { source, stderr } => data_cargo(source, stderr),
         };
 
@@ -161,6 +162,19 @@ fn data_outdated(s: &str) -> Vec<OutputDataInner> {
         let data = OutputDataInner::new(
             "[outdated direct dependencies]".into(),
             Kind::Outdated,
+            s.to_owned(),
+        );
+        vec![data]
+    }
+}
+
+fn data_geiger(s: &str) -> Vec<OutputDataInner> {
+    if s.is_empty() {
+        Vec::new()
+    } else {
+        let data = OutputDataInner::new(
+            "[geiger] Unsafe Code statistics".into(),
+            Kind::Geiger,
             s.to_owned(),
         );
         vec![data]


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/154

![image](https://github.com/user-attachments/assets/24f867d8-badd-4292-9be2-15fb782a00ca)

由于 geiger 需要编译才能检测，这增加了检查时间和编译产物，Github Runner 再次遇到磁盘耗尽。

尝试剔除一些检查，依然磁盘耗尽，于是在 CI 上又耗费了一下午... （写集成的 Rust 代码也才不到 2 小时...）

最终只好检查部分仓库，暂不在这个 PR 中推送到 main database。