### PR TITLE
feat: layout 命令添加 `--list-targets` 参数，以获取给定仓库的 packages 和它们的 targets

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,7 +23,7 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # use which configs
   CONFIGS: repos.json # for debug single repo
   # CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -106,6 +106,10 @@ jobs:
           cp ~/check/cache.redb .
           cargo test -p os-checker-types -- --nocapture cache_redb
 
+      - name: Run layout --list-targets test
+        run: |
+          os-checker layout --list-targets os-checker/os-checker,os-checker/os-checker-test-suite
+
       - name: Update cache.redb
         run: |
           cd ~/check

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,10 +23,10 @@ env:
   # compiled checker binaries
   TAG_CHECKER_DOWNLOAD: cache-v7.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # use which configs
-  CONFIGS: repos.json # for debug single repo
-  # CONFIGS: repos-default.json repos-ui.json # full repo list
+  # CONFIGS: repos.json # for debug single repo
+  CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,7 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # push to which database branch 
-  DATABASE: debug
+  DATABASE: main
   # cache.redb tag in database release
   TAG_CACHE: cache-v11.redb
   # repos-default.json tag in database release

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -107,8 +107,7 @@ jobs:
           cargo test -p os-checker-types -- --nocapture cache_redb
 
       - name: Run layout --list-targets test
-        run: |
-          os-checker layout --list-targets os-checker/os-checker,os-checker/os-checker-test-suite
+        run: make layout_list_targets
 
       - name: Update cache.redb
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,8 +25,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
-  # CONFIGS: repos-ui.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json # full repo list
+  CONFIGS: repos.json # for debug single repo
+  # CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,7 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # push to which database branch 
-  DATABASE: main
+  DATABASE: debug
   # cache.redb tag in database release
   TAG_CACHE: cache-v11.redb
   # repos-default.json tag in database release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"
-exclude = ["assets", ".github", "repos", "tests", "examples", "Makefile"]
+exclude = ["assets", ".github", "repos", "tests", "examples", "Makefile", "dist-workspace.toml"]
 repository = "https://github.com/os-checker/os-checker"
 description = "Run a collection of checkers targeting Rust crates, and report bad checking results and statistics."
 

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@ layout:
 	@os-checker layout $(ARGS_CONFIGS) 2>&1 | tee $(BATCH_DIR)/layout.txt
 
 layout_list_targets:
-	cd $(BASE_DIR)
-	os-checker layout $(ARGS_CONFIGS) --list-targets AsyncModules/embassy-priority
+	cd $(BASE_DIR) && os-checker layout $(ARGS_CONFIGS) --list-targets AsyncModules/embassy-priority
 
 audit:
 	gh release download --clobber -R os-checker/database $(TAG_CACHE) -p cargo-audit -D ~/.cargo/bin/ || make install_audit

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ layout:
 	@os-checker layout $(ARGS_CONFIGS) 2>&1 | tee $(BATCH_DIR)/layout.txt
 
 layout_list_targets:
+	cd assets
 	os-checker layout $(ARGS_CONFIGS) --list-targets AsyncModules/embassy-priority
 
 audit:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ layout:
 	@os-checker layout $(ARGS_CONFIGS) 2>&1 | tee $(BATCH_DIR)/layout.txt
 
 layout_list_targets:
-	cd $(BASE_DIR) && os-checker layout $(ARGS_CONFIGS) --list-targets seL4/rust-sel4,AsyncModules/embassy-priority
+	cd $(BASE_DIR) && os-checker layout $(ARGS_CONFIGS) --list-targets seL4/rust-sel4
 
 audit:
 	gh release download --clobber -R os-checker/database $(TAG_CACHE) -p cargo-audit -D ~/.cargo/bin/ || make install_audit

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ layout:
 	@os-checker layout $(ARGS_CONFIGS) 2>&1 | tee $(BATCH_DIR)/layout.txt
 
 layout_list_targets:
-	cd assets
+	cd $(BASE_DIR)
 	os-checker layout $(ARGS_CONFIGS) --list-targets AsyncModules/embassy-priority
 
 audit:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ clone_database:
 layout:
 	@os-checker layout $(ARGS_CONFIGS) 2>&1 | tee $(BATCH_DIR)/layout.txt
 
+layout_list_targets:
+	os-checker layout $(ARGS_CONFIGS) --list-targets AsyncModules/embassy-priority
+
 audit:
 	gh release download --clobber -R os-checker/database $(TAG_CACHE) -p cargo-audit -D ~/.cargo/bin/ || make install_audit
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ layout:
 	@os-checker layout $(ARGS_CONFIGS) 2>&1 | tee $(BATCH_DIR)/layout.txt
 
 layout_list_targets:
-	cd $(BASE_DIR) && os-checker layout $(ARGS_CONFIGS) --list-targets AsyncModules/embassy-priority
+	cd $(BASE_DIR) && os-checker layout $(ARGS_CONFIGS) --list-targets seL4/rust-sel4,AsyncModules/embassy-priority
 
 audit:
 	gh release download --clobber -R os-checker/database $(TAG_CACHE) -p cargo-audit -D ~/.cargo/bin/ || make install_audit

--- a/assets/repos-ui.json
+++ b/assets/repos-ui.json
@@ -8,7 +8,7 @@
       ]
     }
   },
-  "kern-crates/arceos": {
+  "arceos-org/arceos": {
     "packages": {
       "bwbench-client": {
         "targets": "x86_64-unknown-linux-gnu"
@@ -30,10 +30,10 @@
       }
     }
   },
-  "kern-crates/sel4_cspace": {
+  "rel4team/sel4_cspace": {
     "targets": "riscv64gc-unknown-none-elf"
   },
-  "kern-crates/rcore-tutorial-v3-with-hal-component": {
+  "sysones/rcore-tutorial-v3-with-hal-component": {
     "targets": "x86_64-unknown-linux-gnu"
   },
   "Starry-OS/Starry": {
@@ -42,15 +42,15 @@
   "kern-crates/zCore": {
     "no_install_targets": "x86_64-unknown-uefi"
   },
-  "kern-crates/rboot": {
+  "rcore-os/rboot": {
     "no_install_targets": "x86_64-unknown-uefi"
   },
-  "kern-crates/safe-virtio-drivers": {
+  "os-module/safe-virtio-drivers": {
     "cmds": {
       "mirai": false
     }
   },
-  "kern-crates/rust-sel4": {
+  "seL4/rust-sel4": {
     "meta": {
       "skip_pkg_dir_globs": [
         "crates/examples/**",

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,5 @@
 {
-  "rcore-os/rboot": {}
+  "rcore-os/rboot": {
+    "no_install_targets": "x86_64-unknown-uefi"
+  }
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,3 @@
 {
-  "os-checker/os-checker-test-suite": {}
+  "rcore-os/rboot": {}
 }

--- a/os-checker-types/src/layout.rs
+++ b/os-checker-types/src/layout.rs
@@ -131,6 +131,14 @@ pub struct CacheResolve {
     pub cmd: String,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ListTargets {
+    pub user: XString,
+    pub repo: XString,
+    pub pkg: XString,
+    pub targets: Vec<String>,
+}
+
 #[test]
 fn workspaces() {
     #[derive(Encode, Decode)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -311,6 +311,7 @@ impl ArgsLayout {
     fn execute(&self) -> Result<()> {
         SETUP.store(false, Ordering::Relaxed);
 
+        // FIXME: 我们需要支持 repos 为 None 的情况吗？它代表所有仓库，有意义，但没有需求。
         if self.list_targets.is_some() {
             self.list_targets()?;
         } else {
@@ -322,16 +323,13 @@ impl ArgsLayout {
     }
 
     fn list_targets(&self) -> Result<()> {
-        let repos = self
-            .list_targets
-            .as_deref()
-            .map(|s| s.split(',').collect::<Vec<_>>());
-        let repos = repos.as_deref();
+        let list_targets = self.list_targets.as_deref().unwrap();
+        let repos = list_targets.split(',').collect::<Vec<_>>();
 
         let targets: Vec<_> = configurations(&self.config)?
             .into_inner()
             .into_iter()
-            .filter(|config| config.is_in_repos(repos))
+            .filter(|config| config.is_in_repos(&repos))
             .map(|config| Repo::try_from(config)?.list_targets())
             .collect::<Result<Vec<_>>>()?
             .into_iter()

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -314,6 +314,18 @@ impl ArgsLayout {
     }
 
     fn list_targets(&self) -> Result<()> {
+        let repos = self
+            .list_targets
+            .as_deref()
+            .map(|s| s.split(',').collect::<Vec<_>>());
+        let repos = repos.as_deref();
+
+        let repos: Vec<_> = configurations(configs)?
+            .into_inner()
+            .into_iter()
+            .filter(|config| config.is_in_repos(repos))
+            .map(Repo::try_from)
+            .collect::<Result<_>>()?;
         Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -326,7 +326,10 @@ impl ArgsLayout {
         let list_targets = self.list_targets.as_deref().unwrap();
         let repos = list_targets.split(',').collect::<Vec<_>>();
 
-        let targets: Vec<_> = configurations(&self.config)?
+        let configs = configurations(&self.config)?;
+        configs.check_given_repos(&repos)?;
+
+        let targets: Vec<_> = configs
             .into_inner()
             .into_iter()
             .filter(|config| config.is_in_repos(&repos))

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -44,7 +44,6 @@ pub struct RepoConfig {
 
 impl RepoConfig {
     /// 每个 package 及其对应的检查命令
-    #[instrument(level = "trace")]
     pub fn resolve(&self, repo: &str, packages: &Packages) -> Result<Vec<Resolve>> {
         // validate pkg names in packages
         self.validate_pkgs(repo, packages)?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -201,6 +201,18 @@ impl Configs {
 
         Ok(())
     }
+
+    pub fn check_given_repos(&self, repos: &[&str]) -> Result<()> {
+        let mut set: IndexSet<_> = self.0.iter().map(|c| c.uri.key()).collect();
+        set.sort_unstable();
+        for repo in repos {
+            ensure!(
+                set.contains(repo),
+                "{repo} is not in config repos:\n{set:?}"
+            );
+        }
+        Ok(())
+    }
 }
 
 impl Serialize for Configs {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use eyre::Context;
+use indexmap::IndexSet;
 use itertools::Itertools;
 use os_checker_types::db::ListTargets;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
@@ -50,13 +51,11 @@ impl Config {
         self.uri.user_name()
     }
 
-    pub fn is_in_repos(&self, repos: Option<&[&str]>) -> bool {
-        if let Some(v) = repos {
-            let key = self.uri.key();
-            for &repo in v {
-                if key == repo {
-                    return true;
-                }
+    pub fn is_in_repos(&self, repos: &[&str]) -> bool {
+        let key = self.uri.key();
+        for &repo in repos {
+            if key == repo {
+                return true;
             }
         }
         // the config doesn't belong to any repo in the list, or the list is none

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,6 +49,19 @@ impl Config {
         self.uri.user_name()
     }
 
+    pub fn is_in_repos(&self, repos: Option<&[&str]>) -> bool {
+        if let Some(v) = repos {
+            let key = self.uri.key();
+            for &repo in v {
+                if key == repo {
+                    return true;
+                }
+            }
+        }
+        // the config doesn't belong to any repo in the list, or the list is none
+        false
+    }
+
     pub fn set_db(&mut self, db: Option<Db>) {
         self.db = db;
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ use crate::{
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use eyre::Context;
 use itertools::Itertools;
+use os_checker_types::db::ListTargets;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use serde_json::Value;
 
@@ -90,6 +91,20 @@ impl Config {
 
     pub fn clean_repo_dir(&self) -> Result<()> {
         self.uri.clean_repo_dir()
+    }
+
+    pub fn list_targets(&self, pkgs: &Packages) -> Result<Vec<ListTargets>> {
+        Ok(self
+            .config
+            .selected_pkgs(pkgs)?
+            .into_iter()
+            .map(|(pkg, info)| ListTargets {
+                user: self.user_name().into(),
+                repo: self.repo_name().into(),
+                pkg: pkg.into(),
+                targets: info.targets(),
+            })
+            .collect())
     }
 }
 

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -423,7 +423,7 @@ impl RustToolchain {
 
             let repo_dir = self.toml_path.parent().unwrap();
             let stdout = install_toolchain(repo_dir)?;
-            info!(install = String::from_utf8(stdout)?);
+            info!(install = ?String::from_utf8(stdout)?);
 
             let output = cmd!(
                 "rustup",

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -423,7 +423,11 @@ impl RustToolchain {
 
             let repo_dir = self.toml_path.parent().unwrap();
             let stdout = install_toolchain(repo_dir)?;
-            info!(install = ?String::from_utf8(stdout)?);
+            println!(
+                "{}\ntargets = {:#?}",
+                String::from_utf8(stdout)?,
+                self.targets
+            );
 
             let output = cmd!(
                 "rustup",

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -422,7 +422,8 @@ impl RustToolchain {
             self.need_install_clippy = true;
 
             let repo_dir = self.toml_path.parent().unwrap();
-            install_toolchain(repo_dir)?;
+            let stdout = install_toolchain(repo_dir)?;
+            info!(install = String::from_utf8(stdout)?);
 
             let output = cmd!(
                 "rustup",

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -450,6 +450,10 @@ impl PackageInfoShared {
             })
             .collect()
     }
+
+    pub fn targets(&self) -> Vec<String> {
+        self.targets.clone()
+    }
 }
 
 #[derive(Debug)]

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -259,9 +259,7 @@ impl Layout {
         dbg!(&targets.no_install, &self.installation);
         // remove no_install_targets from global toolchain
         for idx in self.installation.keys().copied() {
-            for no_install in targets.no_install {
-                remove_targets(idx, &targets.no_install);
-            }
+            remove_targets(idx, targets.no_install);
         }
         // remove no_install_targets from local repos
         for no_install in targets.no_install {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -256,6 +256,7 @@ impl Layout {
                 *old = targets.repo.to_vec();
             }
         }
+        dbg!(&targets.no_install, &self.installation);
         for no_install in targets.no_install {
             for v in self.installation.values_mut() {
                 if let Some(pos) = v.iter().position(|t| t == no_install) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -260,10 +260,11 @@ impl Layout {
         for no_install in targets.no_install {
             for v in self.installation.values_mut() {
                 if let Some(pos) = v.iter().position(|t| t == no_install) {
-                    v.remove(pos);
+                    dbg!(v.remove(pos));
                 }
             }
         }
+        dbg!(&self.installation);
     }
 
     /// 安装仓库工具链，并在主机和检查工具所在的工具链上安装 targets。

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -3,7 +3,7 @@
 use crate::{
     config::{Resolve, TargetsSpecifed},
     db::out::{CacheLayout, CachePackageInfo, CacheResolve, CargoMetaData},
-    output::{get_channel, install_toolchain_idx, uninstall_toolchains},
+    output::{get_channel, install_toolchain_idx, remove_targets, uninstall_toolchains},
     run_checker::DbRepo,
     utils::walk_dir,
     Result, XString,
@@ -257,6 +257,13 @@ impl Layout {
             }
         }
         dbg!(&targets.no_install, &self.installation);
+        // remove no_install_targets from global toolchain
+        for idx in self.installation.keys().copied() {
+            for no_install in targets.no_install {
+                remove_targets(idx, &targets.no_install);
+            }
+        }
+        // remove no_install_targets from local repos
         for no_install in targets.no_install {
             for v in self.installation.values_mut() {
                 if let Some(pos) = v.iter().position(|t| t == no_install) {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -256,7 +256,6 @@ impl Layout {
                 *old = targets.repo.to_vec();
             }
         }
-        dbg!(&targets.no_install, &self.installation);
         // remove no_install_targets from global toolchain
         for idx in self.installation.keys().copied() {
             remove_targets(idx, targets.no_install);
@@ -265,11 +264,10 @@ impl Layout {
         for no_install in targets.no_install {
             for v in self.installation.values_mut() {
                 if let Some(pos) = v.iter().position(|t| t == no_install) {
-                    dbg!(v.remove(pos));
+                    v.remove(pos);
                 }
             }
         }
-        dbg!(&self.installation);
     }
 
     /// 安装仓库工具链，并在主机和检查工具所在的工具链上安装 targets。

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,7 +8,7 @@ use std::time::SystemTime;
 mod toolchain;
 pub use toolchain::{
     get_channel, get_toolchain, host_target_triple, host_toolchain, init_toolchain_info,
-    install_toolchain_idx, push_toolchain, uninstall_toolchains, RustToolchains,
+    install_toolchain_idx, push_toolchain, remove_targets, uninstall_toolchains, RustToolchains,
 };
 
 #[derive(Debug, Serialize)]

--- a/src/output/toolchain.rs
+++ b/src/output/toolchain.rs
@@ -2,7 +2,7 @@ use crate::{cli::is_not_layout, layout::RustToolchain, Result};
 use cargo_metadata::camino::Utf8Path;
 use duct::cmd;
 use eyre::ContextCompat;
-use indexmap::IndexMap;
+use indexmap::{map::MutableKeys, IndexMap};
 use regex::Regex;
 use serde::Serialize;
 use std::sync::{LazyLock, Mutex};
@@ -109,6 +109,19 @@ pub fn get_toolchain(idx: usize) -> String {
     let mut toolchain = String::new();
     get_toolchain_f(idx, |t| toolchain = t.channel.clone());
     toolchain
+}
+
+pub fn remove_targets(idx: usize, remove: &[String]) {
+    let map = &mut *GLOBAL.installed.lock().unwrap();
+    let toolchain = map.get_index_mut2(idx).unwrap().0;
+    let Some(targets) = &mut toolchain.targets else {
+        return;
+    };
+    for no_install in remove {
+        if let Some(pos) = targets.iter().position(|t| t == no_install) {
+            dbg!(targets.remove(pos));
+        }
+    }
 }
 
 /// 这和 get_toolchain 获取的 channel 几乎一样，但在主机工具链上，统一为

--- a/src/output/toolchain.rs
+++ b/src/output/toolchain.rs
@@ -119,7 +119,7 @@ pub fn remove_targets(idx: usize, remove: &[String]) {
     };
     for no_install in remove {
         if let Some(pos) = targets.iter().position(|t| t == no_install) {
-            dbg!(targets.remove(pos));
+            targets.remove(pos);
         }
     }
 }

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -131,13 +131,16 @@ impl Repo {
         }
     }
 
-    fn run_check(&self, info: &InfoKeyValue) -> Result<PackagesOutputs> {
+    fn run_check(
+        &self,
+        info: &InfoKeyValue,
+        install_err: Option<String>,
+    ) -> Result<PackagesOutputs> {
         let user = self.config.user_name();
         let repo = self.config.repo_name();
         let _span = debug_span!("run_check", user, repo).entered();
 
         let mut outputs = PackagesOutputs::new();
-        let err_or_resolve = self.resolve()?;
 
         let db = self.config.db();
         let repo = {
@@ -147,6 +150,12 @@ impl Repo {
         info.assert_eq_sha(&repo);
         let db_repo = db.map(|db| DbRepo::new(db, &repo, info));
 
+        if let Some(err) = install_err {
+            self.push_cargo_layout_parse_error(&err, &mut outputs, db_repo);
+            return Ok(outputs);
+        }
+
+        let err_or_resolve = self.resolve()?;
         match err_or_resolve {
             Either::Left(mut resolves) => {
                 self.layout.set_layout_cache(&resolves, db_repo);
@@ -161,14 +170,23 @@ impl Repo {
             }
             Either::Right(err) => {
                 self.layout.set_layout_cache(&[], db_repo);
-                // NOTE: 无法从 repo 中知道 pkg 信息，因此为空
-                let pkg_name = String::new();
-                let repo_root = self.layout.repo_root();
-                let output = Output::new_cargo_from_layout_parse_error(&pkg_name, repo_root, err);
-                outputs.push_cargo_layout_parse_error(pkg_name, output, db_repo);
+                self.push_cargo_layout_parse_error(err, &mut outputs, db_repo);
             }
         }
         Ok(outputs)
+    }
+
+    fn push_cargo_layout_parse_error(
+        &self,
+        err: &str,
+        outputs: &mut PackagesOutputs,
+        db_repo: Option<DbRepo<'_>>,
+    ) {
+        // NOTE: 无法从 repo 中知道 pkg 信息，因此为空
+        let pkg_name = String::new();
+        let repo_root = self.layout.repo_root();
+        let output = Output::new_cargo_from_layout_parse_error(&pkg_name, repo_root, err);
+        outputs.push_cargo_layout_parse_error(pkg_name, output, db_repo);
     }
 
     /// 提前删除仓库目录
@@ -242,9 +260,12 @@ impl RepoOutput {
             .set_installation_targets(repo.config.targets_specified());
 
         info!(repo_root = %repo.layout.repo_root(), "install toolchains");
-        repo.layout.install_toolchains()?;
+        let install_err = match repo.layout.install_toolchains() {
+            Ok(_) => None,
+            Err(err) => Some(format!("{err:?}")),
+        };
 
-        let mut outputs = repo.run_check(&info)?;
+        let mut outputs = repo.run_check(&info, install_err)?;
         outputs.sort_by_name_and_checkers();
         if let Some(db) = repo.config.db() {
             info.set_complete(db)?;

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -13,6 +13,7 @@ use cargo_metadata::{
 use either::Either;
 use eyre::Context;
 use itertools::Itertools;
+use os_checker_types::db::ListTargets;
 use regex::Regex;
 use serde::Deserialize;
 use std::{process::Output as RawOutput, sync::LazyLock};
@@ -174,6 +175,10 @@ impl Repo {
     #[instrument(level = "trace")]
     pub fn clean_repo_dir(&self) -> Result<()> {
         self.config.clean_repo_dir()
+    }
+
+    pub fn list_targets(&self) -> Result<Vec<ListTargets>> {
+        self.config.list_targets(&self.layout.packages()?)
     }
 }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -169,7 +169,6 @@ impl Repo {
                 }
             }
             Either::Right(err) => {
-                self.layout.set_layout_cache(&[], db_repo);
                 self.push_cargo_layout_parse_error(err, &mut outputs, db_repo);
             }
         }
@@ -182,6 +181,7 @@ impl Repo {
         outputs: &mut PackagesOutputs,
         db_repo: Option<DbRepo<'_>>,
     ) {
+        self.layout.set_layout_cache(&[], db_repo);
         // NOTE: 无法从 repo 中知道 pkg 信息，因此为空
         let pkg_name = String::new();
         let repo_root = self.layout.repo_root();

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -262,7 +262,7 @@ impl RepoOutput {
         info!(repo_root = %repo.layout.repo_root(), "install toolchains");
         let install_err = match repo.layout.install_toolchains() {
             Ok(_) => None,
-            Err(err) => Some(format!("{err:?}")),
+            Err(err) => Some(strip_ansi_escapes::strip_str(format!("{err:?}"))),
         };
 
         let mut outputs = repo.run_check(&info, install_err)?;

--- a/src/run_checker/utils.rs
+++ b/src/run_checker/utils.rs
@@ -16,6 +16,7 @@ use std::{fmt::Write, sync::LazyLock};
 
 /// 当 os-checker 内部支持新检查时，将这个值设置为 true，
 /// 来强制运行仓库检查（不影响已有的检查缓存结果）。
+/// NOTE: cargo error 的检查结果总是在强制运行仓库检查时更新。
 pub fn force_repo_check() -> bool {
     static FORCE_REPO_CHECK: LazyLock<bool> = LazyLock::new(|| {
         std::env::var("FORCE_REPO_CHECK")


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/165

* 仓库名以逗号分隔，示例 `a/b,c/d`；plugin-cargo 应该每次只需要一个仓库 `a/b`
* 该命令会下载仓库、工具链：下载仓库工具链其实不是必须的，但目前它位于生成 layout 阶段，暂时不修改代码，因为运行测试需要下载工具链
* 只通过向 stdout 输出 JSON 格式，该格式可解析为 os-checker-types crate 中的 `Vec<ListTargets>` 

```rust
#[derive(Serialize, Deserialize, Debug)]
pub struct ListTargets {
    pub user: XString,
    pub repo: XString,
    pub pkg: XString,
    pub targets: Vec<String>,
}
```

* 会检查输入的仓库是否在配置文件中，如果不在，则产生 error：

```rust
Error: 
   0: seL4/rust-sel4 is not in config repos:
      {"AsyncModules/embassy-priority", "Azure-stars/elf_parser_rs", "Byte-OS/ByteOS", "Byte-OS/lose-net-stack", "Byte-OS/polyhal", "Godones/loongArch64", "Godones/rCoreloongArch", "Starry-OS/Starry", "Starry-OS/arm_gic", "Starry-OS/axprocess", "Starry-OS/dw_apb_uart", "Starry-OS/of", "Starry-OS/percpu_macros", "Starry-OS/slab_allocator", "Starry-OS/spinlock", "Starry-OS/tuple_for_each", "ZR233/arm-gic-driver", "ZR233/arm-pl011-rs", "ZR233/ostool", "arceos-hypervisor/arm_vcpu", "arceos-hypervisor/arm_vgic", "arceos-hypervisor/axaddrspace", "arceos-hypervisor/axdevice", "arceos-hypervisor/axvcpu", "arceos-hypervisor/axvm", "arceos-hypervisor/riscv_vcpu", "arceos-hypervisor/x86_vcpu", "arceos-org/allocator", "arceos-org/arceos", "arceos-org/arm_gicv2", "arceos-org/arm_pl011", "arceos-org/arm_pl031", "arceos-org/axdriver_crates", "arceos-org/axerrno", "arceos-org/axfs_crates", "arceos-org/axio", "arceos-org/axmm_crates", "arceos-org/cap_access", "arceos-org/cpumask", "arceos-org/crate_interface", "arceos-org/flatten_objects", "arceos-org/handler_table", "arceos-org/int_ratio", "arceos-org/kernel_guard", "arceos-org/kspin", "arceos-org/lazyinit", "arceos-org/linked_list_r4l", "arceos-org/memory_set", "arceos-org/page_table_multiarch", "arceos-org/percpu", "arceos-org/scheduler", "arceos-org/starry-next", "arceos-org/timer_list", "elliott10/e1000-driver", "elliott10/lwext4_rust", "guoweikang/osl", "kern-crates/CSpace", "kern-crates/arceos", "kern-crates/axbacktrace", "kern-crates/axhal_split", "kern-crates/r4l", "kern-crates/rboot", "kern-crates/rcore-tutorial-v3-with-hal-component", "kern-crates/rust-sel4", "kern-crates/safe-virtio-drivers", "kern-crates/sel4_cspace", "kern-crates/test-test-repo", "kern-crates/virtio-input-decoder", "kern-crates/zCore", "kern-crates/zcore-drivers", "kern-crates/zcore-kernel-hal", "kern-crates/zcore-linux-object", "kern-crates/zcore-linux-syscall", "kern-crates/zcore-loader", "kern-crates/zcore-zircon-object", "kern-crates/zcore-zircon-syscall", "kern-crates/zcore-zircon-user", "os-module/pager", "os-module/pconst", "os-module/rtc", "os-module/safe-virtio-drivers", "os-module/syscall-table", "os-module/tracer", "os-module/uart16550", "os-module/virt2slint", "os-module/visionfive2-sd", "qclic/e1000e-frame", "qclic/fdt-parser", "rcore-os/rboot", "rel4team/sel4_common", "rel4team/sel4_cspace", "rel4team/sel4_ipc", "rel4team/sel4_task", "rel4team/sel4_vspace", "shilei-massclouds/arch_boot", "shilei-massclouds/axalloc", "shilei-massclouds/axdtb", "shilei-massclouds/axfs_ramfs", "shilei-massclouds/axhal", "shilei-massclouds/axlog2", "shilei-massclouds/axmount", "shilei-massclouds/driver_block", "shilei-massclouds/driver_virtio", "shilei-massclouds/early_console", "shilei-massclouds/exec", "shilei-massclouds/fileops", "shilei-massclouds/fork", "shilei-massclouds/fstree", "shilei-massclouds/mm", "shilei-massclouds/mmap", "shilei-massclouds/mutex", "shilei-massclouds/page_table", "shilei-massclouds/run_queue", "yuoo655/ext4_rs", "yuoo655/ext4libtest"}

Location:
   src/config/mod.rs:209
```