### PR TITLE
feat: support `OS_CHECKER_CONFIGS` which is used when `--config` is omitted

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -93,8 +93,8 @@ jobs:
           cp ~/check/cache.redb .
           cargo test -p os-checker-types -- --nocapture cache_redb
 
-      - name: Run layout --list-targets test
-        run: make layout_list_targets
+      # - name: Run layout --list-targets test
+      #   run: make layout_list_targets
 
       - name: Update cache.redb
         run: |

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,8 +25,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
-  # CONFIGS: repos.json # for debug single repo
-  CONFIGS: repos-default.json repos-ui.json # full repo list
+  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 BASE_DIR ?= ~/check
 BATCH_DIR ?= $(BASE_DIR)/batch
 # CONFIG_DIR ?= $(BASE_DIR)/config
-CONFIGS ?= repos-default.json repos-ui.json repos-embassy.json
-ARGS_CONFIGS ?= $(shell echo "$(CONFIGS)" | awk '{for(i=1;i<=NF;i++) printf("--config %s ", $$i)}')
+OS_CHECKER_CONFIGS ?= repos-default.json repos-ui.json
 TAG_PRECOMPILED_CHECKERS ?= precompiled-checkers
 
 ifeq ($(PUSH),true)
@@ -21,7 +20,7 @@ upload:
 	gh release upload --clobber -R os-checker/database $(TAG_PRECOMPILED_CHECKERS)  ~/.cargo/bin/os-checker
 
 run:
-	@os-checker run $(ARGS_CONFIGS) --emit $(SINGLE_JSON) --db cache.redb
+	@OS_CHECKER_CONFIGS=$(OS_CHECKER_CONFIGS) os-checker run --emit $(SINGLE_JSON) --db cache.redb
 
 # author zjp-CN, and commiter bot
 clone_database:
@@ -36,10 +35,10 @@ clone_database:
 
 # print repos info without installing anything
 layout:
-	@os-checker layout $(ARGS_CONFIGS) 2>&1 | tee $(BATCH_DIR)/layout.txt
+	@OS_CHECKER_CONFIGS=$(OS_CHECKER_CONFIGS) os-checker layout 2>&1 | tee $(BATCH_DIR)/layout.txt
 
 layout_list_targets:
-	cd $(BASE_DIR) && os-checker layout $(ARGS_CONFIGS) --list-targets seL4/rust-sel4
+	cd $(BASE_DIR) && OS_CHECKER_CONFIGS=$(OS_CHECKER_CONFIGS) os-checker layout --list-targets seL4/rust-sel4
 
 audit:
 	gh release download --clobber -R os-checker/database $(TAG_CACHE) -p cargo-audit -D ~/.cargo/bin/ || make install_audit

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ upload:
 	gh release upload --clobber -R os-checker/database $(TAG_PRECOMPILED_CHECKERS)  ~/.cargo/bin/os-checker
 
 run:
-	@OS_CHECKER_CONFIGS=$(OS_CHECKER_CONFIGS) os-checker run --emit $(SINGLE_JSON) --db cache.redb
+	@OS_CHECKER_CONFIGS="$(OS_CHECKER_CONFIGS)" os-checker run --emit $(SINGLE_JSON) --db cache.redb
 
 # author zjp-CN, and commiter bot
 clone_database:
@@ -35,10 +35,10 @@ clone_database:
 
 # print repos info without installing anything
 layout:
-	@OS_CHECKER_CONFIGS=$(OS_CHECKER_CONFIGS) os-checker layout 2>&1 | tee $(BATCH_DIR)/layout.txt
+	@OS_CHECKER_CONFIGS="$(OS_CHECKER_CONFIGS)" os-checker layout 2>&1 | tee $(BATCH_DIR)/layout.txt
 
 layout_list_targets:
-	cd $(BASE_DIR) && OS_CHECKER_CONFIGS=$(OS_CHECKER_CONFIGS) os-checker layout --list-targets seL4/rust-sel4
+	cd $(BASE_DIR) && OS_CHECKER_CONFIGS="$(OS_CHECKER_CONFIGS)" os-checker layout --list-targets seL4/rust-sel4
 
 audit:
 	gh release download --clobber -R os-checker/database $(TAG_CACHE) -p cargo-audit -D ~/.cargo/bin/ || make install_audit

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -36,8 +36,10 @@ fn main() -> Result<()> {
     args.extend(["--out-dir", config_dir.as_str()]);
     args.extend(["--size", &batch.size]);
 
+    let configs = var(OS_CHECKER_CONFIGS)?;
+    info!(?configs);
     cmd("os-checker", args)
-        .env(OS_CHECKER_CONFIGS, var(OS_CHECKER_CONFIGS)?)
+        .env(OS_CHECKER_CONFIGS, configs)
         .run()?;
 
     let [mut count_json_file, mut count_repos] = [0usize; 2];

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -1,9 +1,6 @@
 // #!/usr/bin/env -S cargo +nightly -Zscript
 
 #[macro_use]
-extern crate eyre;
-
-#[macro_use]
 extern crate tracing;
 
 use argh::FromArgs;
@@ -33,21 +30,8 @@ fn main() -> Result<()> {
     let config_dir = base_dir.join("config");
     let batch_dir = base_dir.join("batch");
 
-    let configs: Vec<_> = var("CONFIGS")?
-        .trim()
-        .split(" ")
-        .map(Utf8PathBuf::from)
-        .collect();
-    info!(?configs);
-    ensure!(!configs.is_empty(), "CONFIGS env var should be specified.");
-    for config in &configs {
-        ensure!(config.exists(), "{config} does not exists.");
-    }
-    let arg_configs = configs.iter().flat_map(|c| ["--config", c.as_str()]);
-
     let mut args = Vec::<&str>::with_capacity(16);
     args.push("batch");
-    args.extend(arg_configs);
     args.extend(["--out-dir", config_dir.as_str()]);
     args.extend(["--size", &batch.size]);
     cmd("os-checker", args).run()?;

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -18,6 +18,7 @@ struct Batch {
 }
 
 const DB: &str = "cache.redb";
+const OS_CHECKER_CONFIGS: &str = "OS_CHECKER_CONFIGS";
 
 #[instrument(level = "trace")]
 fn main() -> Result<()> {
@@ -34,7 +35,10 @@ fn main() -> Result<()> {
     args.push("batch");
     args.extend(["--out-dir", config_dir.as_str()]);
     args.extend(["--size", &batch.size]);
-    cmd("os-checker", args).run()?;
+
+    cmd("os-checker", args)
+        .env(OS_CHECKER_CONFIGS, var(OS_CHECKER_CONFIGS)?)
+        .run()?;
 
     let [mut count_json_file, mut count_repos] = [0usize; 2];
     // NOTE: 这里没有对文件排序，所以不是完全按字母表顺序检查（虽然文件内的仓库是字母顺序）

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -77,6 +77,8 @@ impl Args {
 
     /// Try reading `OS_CHECKER_CONFIGS` env var if no config is given.
     fn set_configs(&mut self) -> Result<()> {
+        const OS_CHECKER_CONFIGS: &str = "OS_CHECKER_CONFIGS";
+
         let mut_config = match &mut self.sub_args {
             SubArgs::Layout(layout) => &mut layout.config,
             SubArgs::Run(run) => &mut run.config,
@@ -85,11 +87,13 @@ impl Args {
             SubArgs::Db(_) => return Ok(()),
         };
         if mut_config.is_empty() {
-            if let Ok(configs) = std::env::var("OS_CHECKER_CONFIGS") {
-                info!("Set OS_CHECKER_CONFIGS as --config arguments.");
+            if let Ok(configs) = std::env::var(OS_CHECKER_CONFIGS) {
+                info!("Set {OS_CHECKER_CONFIGS} as --config arguments.");
                 mut_config.extend(configs.trim().split(" ").map(|c| c.trim().to_owned()));
             } else {
-                bail!("Neither OS_CHECKER_CONFIGS nor --config exists. Please provide one of them.")
+                bail!(
+                    "Neither {OS_CHECKER_CONFIGS} nor --config exists. Please provide one of them."
+                )
             }
         }
         Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -96,6 +96,7 @@ impl Args {
                 )
             }
         }
+        info!(?mut_config);
         Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,9 +37,8 @@ pub struct Args {
 impl Args {
     #[instrument(level = "trace")]
     pub fn execute(mut self) -> Result<()> {
-        init_repos_base_dir(self.base_dir());
-
         self.set_configs()?;
+        init_repos_base_dir(self.base_dir());
 
         match self.sub_args {
             SubArgs::Layout(layout) => layout.execute()?,
@@ -96,7 +95,6 @@ impl Args {
                 )
             }
         }
-        info!(?mut_config);
         Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -88,7 +88,10 @@ impl Args {
             return;
         }
         if let Ok(configs) = std::env::var("OS_CHECKER_CONFIGS") {
+            info!("Set OS_CHECKER_CONFIGS as --config arguments.");
             mut_config.extend(configs.trim().split(" ").map(|c| c.trim().to_owned()));
+        } else {
+            bail!("Neither OS_CHECKER_CONFIGS nor --config exists. Please provide one of them.")
         }
     }
 }


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/180