### PR TITLE
feat: 更新默认工具链到 2024-12-24；使用 cargo-outdated fork

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,8 +24,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -18,14 +18,14 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # push to which database branch 
-  DATABASE: main
+  DATABASE: debug
   # cache.redb tag in database release
   TAG_CACHE: cache-v11.redb
   # force downloading repos and check running
   FORCE_REPO_CHECK: false
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -51,11 +51,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-11-21
+          toolchain: nightly-2024-12-24
           components: rustfmt, clippy
 
       - name: Install Checkers
         run: |
+          rustup default
           gh release download --clobber -R os-checker/database precompiled-checkers -p checkers.tar.xz
           tar -xvJf checkers.tar.xz -C ~/.cargo/bin/
           cargo audit --version
@@ -66,6 +67,7 @@ jobs:
           rustup default nightly-2024-02-05 && cargo mirai --help
           rustup default nightly-2024-10-05 && cargo lockbud --help
           rustup default nightly-2024-10-12 && cargo rap --help
+          rustup default nightly-2024-12-24
 
       - name: Install os-checker
         run: cargo install --path . --force

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,8 +24,8 @@ env:
   # force downloading repos and check running
   FORCE_REPO_CHECK: true
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -22,7 +22,7 @@ env:
   # cache.redb tag in database release
   TAG_CACHE: cache-v11.redb
   # force downloading repos and check running
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # use which configs
   OS_CHECKER_CONFIGS: repos.json # for debug single repo
   # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,4 +1,3 @@
 {
-  "os-checker/os-checker-test-suite": {},
-  "arceos-org/flatten_objects": {}
+  "arceos-org/page_table_multiarch": {}
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,4 @@
 {
-  "os-checker/os-checker-test-suite": {}
+  "os-checker/os-checker-test-suite": {},
+  "arceos-org/flatten_objects": {}
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,3 @@
 {
-  "shilei-massclouds/fileops": {}
+  "os-checker/os-checker-test-suite": {}
 }

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -115,10 +115,13 @@ impl Repo {
             .with_context(|| eyre!("无法解析 `{repo_root}` 内的 Rust 项目布局"));
         match layout {
             Ok(layout) => Self { layout, config },
-            Err(err) => Self {
-                layout: Layout::empty(repo_root, err),
-                config,
-            },
+            Err(err) => {
+                error!(?err);
+                Self {
+                    layout: Layout::empty(repo_root, err),
+                    config,
+                }
+            }
         }
     }
 


### PR DESCRIPTION
该 PR 包含以下功能：
* 更新工具链来更新所有数据
* 使用 os-checker 自己维护的 cargo-outdated  https://github.com/os-checker/dockerfiles/pull/3
* close https://github.com/os-checker/os-checker/issues/196
* close https://github.com/os-checker/os-checker/issues/206
* close https://github.com/os-checker/os-checker/issues/222