### PR TITLE
feat: cargo 诊断增加时间戳；rap 在检测到的 targets 上运行；更新默认工具链到 nightly-2024-12-25

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,6 +17,7 @@ env:
   # false: run with json stdout emitted, and no interaction with database;
   # true: run with json file emitted, and push it to database.
   PUSH: true
+  toolchain: nightly-2024-12-25
   # push to which database branch 
   DATABASE: debug
   # cache.redb tag in database release
@@ -51,7 +52,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-12-24
+          toolchain: ${{ env.toolchain }}
           components: rustfmt, clippy
 
       - name: Install Checkers
@@ -67,7 +68,7 @@ jobs:
           rustup default nightly-2024-02-05 && cargo mirai --help
           rustup default nightly-2024-10-05 && cargo lockbud --help
           rustup default nightly-2024-10-12 && cargo rap --help
-          rustup default nightly-2024-12-24
+          rustup default ${{ env.toolchain }}
 
       - name: Install os-checker
         run: cargo install --path . --force

--- a/os-checker-database/src/file_tree/mod.rs
+++ b/os-checker-database/src/file_tree/mod.rs
@@ -74,7 +74,7 @@ pub struct FileTree<'a> {
     kinds_order: &'a [Kind],
 }
 
-impl<'a> FileTree<'a> {
+impl FileTree<'_> {
     pub fn split_by_repo(&self) -> Vec<FileTreeRepo> {
         let kinds_order = self.kinds_order;
         let group_by_repo = group_by(&self.data, |d| d.pkg.into_repo());
@@ -115,7 +115,7 @@ pub struct FileTreeRepo<'a> {
     kinds_order: &'a [Kind],
 }
 
-impl<'a> FileTreeRepo<'a> {
+impl FileTreeRepo<'_> {
     pub fn dir(&self) -> Utf8PathBuf {
         Utf8PathBuf::from_iter(["repos", self.repo.user, self.repo.repo])
     }

--- a/os-checker-database/src/utils.rs
+++ b/os-checker-database/src/utils.rs
@@ -28,7 +28,7 @@ pub struct UserRepo<'a> {
     pub repo: &'a str,
 }
 
-impl<'a> UserRepo<'a> {
+impl UserRepo<'_> {
     pub fn print(self) {
         let Self { user, repo } = self;
         info!("{user}/{repo}");

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -134,13 +134,7 @@ impl Resolve {
     }
 
     pub fn rap(pkgs: &[Pkg], resolved: &mut Vec<Self>) {
-        resolved.reserve(pkgs.len() * 2);
-        for pkg in pkgs {
-            // FIXME: 暂时只在 x86_64-unknown-linux-gnu 上检查（Rap 已经支持条件编译参数）
-            if pkg.target == HOST_TARGET {
-                resolved.push(cargo_rap(pkg));
-            }
-        }
+        resolved.extend(pkgs.iter().map(cargo_rap));
     }
 
     pub fn rudra(pkgs: &[Pkg], resolved: &mut Vec<Self>) {

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -455,7 +455,7 @@ fn run_check(
         resolve,
     };
 
-    outputs.push_output_with_cargo(output, db_repo);
+    outputs.push_output_with_cargo(output, db_repo, now_utc);
 
     Ok(())
 }

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -17,6 +17,7 @@ use os_checker_types::db::ListTargets;
 use regex::Regex;
 use serde::Deserialize;
 use std::{process::Output as RawOutput, sync::LazyLock};
+use time::OffsetDateTime;
 
 mod geiger;
 mod lockbud;
@@ -287,6 +288,7 @@ pub struct Output {
     parsed: OutputParsed,
     /// 该检查工具报告的总数量；与最后 os-checker 提供原始输出计算的数量应该一致
     count: usize,
+    now_utc: OffsetDateTime,
     duration_ms: u64,
     resolve: Resolve,
 }
@@ -297,6 +299,7 @@ impl std::fmt::Debug for Output {
             // .field("raw", &self.raw)
             // .field("parsed", &self.parsed)
             .field("count", &self.count)
+            .field("now_utc", &self.now_utc)
             .field("duration_ms", &self.duration_ms)
             .field("resolve", &self.resolve)
             .finish()
@@ -322,6 +325,7 @@ impl Output {
                 stderr: stderr_parsed,
             },
             count: 1, // 因为每个 checker 最多产生一个 cargo 诊断的方法
+            now_utc: OffsetDateTime::now_utc(),
             duration_ms: self.duration_ms,
             resolve: self.resolve.new_cargo(),
         }
@@ -342,6 +346,7 @@ impl Output {
             raw,
             parsed,
             count: 1,
+            now_utc: OffsetDateTime::now_utc(),
             duration_ms: 0,
             resolve: Resolve::new_cargo_layout_parse_error(pkg_name, repo_root.into()),
         }
@@ -371,7 +376,7 @@ fn run_check(
     }
 
     let expr = resolve.expr.clone();
-    let (duration_ms, raw) = crate::utils::execution_time_ms(|| {
+    let (now_utc, duration_ms, raw) = crate::utils::execution_time_ms(|| {
         expr.stderr_capture().stdout_capture().unchecked().run()
     });
     let raw = raw?;
@@ -445,6 +450,7 @@ fn run_check(
         raw,
         parsed,
         count,
+        now_utc,
         duration_ms,
         resolve,
     };

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -77,11 +77,12 @@ pub fn walk_dir<T>(
 }
 
 /// Perform an operation and get the execution time.
-pub fn execution_time_ms<T>(op: impl FnOnce() -> T) -> (u64, T) {
+pub fn execution_time_ms<T>(op: impl FnOnce() -> T) -> (time::OffsetDateTime, u64, T) {
+    let now_utc = time::OffsetDateTime::now_utc();
     let now = Instant::now();
     let value = op();
     let duration_ms = now.elapsed().as_millis() as u64;
-    (duration_ms, value)
+    (now_utc, duration_ms, value)
 }
 
 /// ignore_fail means when the cmd returns error, still reads stdout.


### PR DESCRIPTION
* close https://github.com/os-checker/os-checker/issues/217
* 放宽 rap 的检查范围：从 x86_64-unknown-linux-gnu 到检测到的所有 targets 上运行
* 更新默认工具链到 nightly-2024-12-25：因为检查结果发生变化，但检查命令未改变

![截图_20241226233103](https://github.com/user-attachments/assets/dc45acf8-11ea-4ca2-a1bc-d18384136aa5)
