### PR TITLE
fix: 在仓库和 package 中指定的 targets 应追加到安装列表，而不是覆盖安装列表

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -22,11 +22,13 @@ env:
   DATABASE: debug
   # cache.redb tag in database release
   TAG_CACHE: cache-v11.redb
-  # force downloading repos and check running
-  FORCE_REPO_CHECK: false
+  # force downloading repos to run check 
+  FORCE_REPO_CHECK: true
+  # force running checks after downloading repos
+  FORCE_RUN_CHECK: true
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,9 @@
 {
-  "qclic/fdt-parser": {}
+  "qclic/fdt-parser": {
+    "packages": {
+      "dtb-tool": {
+        "targets": "x86_64-unknown-linux-gnu"
+      }
+    }
+  }
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,6 +1,3 @@
 {
-  "arceos-org/page_table_multiarch": {},
-  "arceos-hypervisor/axdevice": {},
-  "ZR233/arm-gic-driver": {},
-  "Starry-OS/arm_gic": {}
+  "qclic/fdt-parser": {}
 }

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -367,6 +367,7 @@ impl RustToolchain {
             return Ok(None);
         };
         let mut toolchain = toolchain.toolchain;
+        info!(%toml_path);
         toolchain.toml_path = toml_path;
         if is_not_layout() {
             // 不再解析工具链时安装这些，因为每个 pkg 检查工作空间下的
@@ -402,6 +403,7 @@ impl RustToolchain {
     pub fn install_targets(&self) -> Result<()> {
         if let Some(targets) = self.targets.as_deref() {
             let targets: Vec<_> = targets.iter().map(|s| s.as_str()).collect();
+            info!(%self.toml_path);
             let repo_dir = self.toml_path.parent().unwrap();
             rustup_target_add(&targets, repo_dir)?;
             rustup_target_add_for_checkers(&targets)?;

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -304,6 +304,7 @@ pub struct RustToolchain {
     pub profile: Option<XString>,
     pub targets: Option<Vec<String>>,
     pub components: Option<Vec<String>>,
+    /// 默认为空路径
     #[serde(skip_deserializing)]
     pub toml_path: Utf8PathBuf,
     /// 如果仓库的工具链没写 clippy，那么该字段为 true，表示 os-checker 会安装它
@@ -367,7 +368,6 @@ impl RustToolchain {
             return Ok(None);
         };
         let mut toolchain = toolchain.toolchain;
-        info!(%toml_path);
         toolchain.toml_path = toml_path;
         if is_not_layout() {
             // 不再解析工具链时安装这些，因为每个 pkg 检查工作空间下的
@@ -403,7 +403,6 @@ impl RustToolchain {
     pub fn install_targets(&self) -> Result<()> {
         if let Some(targets) = self.targets.as_deref() {
             let targets: Vec<_> = targets.iter().map(|s| s.as_str()).collect();
-            info!(%self.toml_path);
             let repo_dir = self.toml_path.parent().unwrap();
             rustup_target_add(&targets, repo_dir)?;
             rustup_target_add_for_checkers(&targets)?;

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -241,7 +241,6 @@ impl Layout {
 
     pub fn set_installation_targets(&mut self, targets: TargetsSpecifed) {
         // 如果配置文件设置了 targets，则直接覆盖
-        let repo_overridden = !targets.repo.is_empty();
         for info in &self.packages_info {
             let old = self
                 .installation
@@ -250,12 +249,12 @@ impl Layout {
             if let Some(pkg_targets) = targets.pkgs.get(&*info.pkg_name) {
                 // append package targets
                 old.extend_from_slice(pkg_targets);
-                old.sort_unstable();
-                old.dedup();
-            } else if repo_overridden {
-                // override repo targets
-                *old = targets.repo.to_vec();
             }
+            // append repo targets
+            old.extend_from_slice(targets.repo);
+            // remove repeated targets
+            old.sort_unstable();
+            old.dedup();
         }
         // remove no_install_targets from global toolchain
         for idx in self.installation.keys().copied() {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -356,7 +356,6 @@ fn installation(info: &[PackageInfo]) -> IndexMap<usize, Vec<String>> {
         v.sort_unstable();
         v.dedup();
     }
-    info!(?map);
     map
 }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -248,8 +248,12 @@ impl Layout {
                 .get_mut(&info.toolchain.unwrap_or(0))
                 .unwrap();
             if let Some(pkg_targets) = targets.pkgs.get(&*info.pkg_name) {
-                *old = pkg_targets.to_vec();
+                // append package targets
+                old.extend_from_slice(pkg_targets);
+                old.sort_unstable();
+                old.dedup();
             } else if repo_overridden {
+                // override repo targets
                 *old = targets.repo.to_vec();
             }
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -353,6 +353,7 @@ fn installation(info: &[PackageInfo]) -> IndexMap<usize, Vec<String>> {
         v.sort_unstable();
         v.dedup();
     }
+    info!(?map);
     map
 }
 

--- a/src/output/toolchain.rs
+++ b/src/output/toolchain.rs
@@ -145,11 +145,8 @@ pub fn install_toolchain_idx(idx: usize, targets: &[String]) -> Result<()> {
     let mut toolchain = get_toolchain_owned(idx)?;
 
     // 合并新的 targets 并安装它们
-    info!(?toolchain);
     toolchain.append_targets(targets);
-    info!(?toolchain);
     toolchain.install_toolchain_and_components()?;
-    info!(?targets, ?toolchain.targets);
     toolchain.install_targets()?;
 
     Ok(())

--- a/src/output/toolchain.rs
+++ b/src/output/toolchain.rs
@@ -145,8 +145,11 @@ pub fn install_toolchain_idx(idx: usize, targets: &[String]) -> Result<()> {
     let mut toolchain = get_toolchain_owned(idx)?;
 
     // 合并新的 targets 并安装它们
+    info!(?toolchain);
     toolchain.append_targets(targets);
+    info!(?toolchain);
     toolchain.install_toolchain_and_components()?;
+    info!(?targets, ?toolchain.targets);
     toolchain.install_targets()?;
 
     Ok(())

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -370,8 +370,8 @@ fn run_check(
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
     // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
-    // if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
-    if outputs.fetch_cache(&resolve, db_repo) {
+    // if !utils::force_run_check() && !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
+    if !utils::force_run_check() && outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -24,7 +24,7 @@ pub fn install_toolchain(dir: &Utf8Path) -> Result<Vec<u8>> {
 
 pub fn rustup_target_add(targets: &[&str], dir: &Utf8Path) -> Result<()> {
     let expr = cmd("rustup", ["target", "add"].iter().chain(targets)).dir(dir);
-    info!(?expr, ?targets, %dir);
+    // info!(?expr, ?targets, %dir);
     run_cmd(expr, || {
         format!("在 {dir:?} 目录下安装如下 targets {targets:?} 失败")
     })

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -1,4 +1,3 @@
-use super::{PLUS_TOOLCHAIN_HOST, PLUS_TOOLCHAIN_LOCKBUD, PLUS_TOOLCHAIN_MIRAI};
 use crate::Result;
 use cargo_metadata::camino::Utf8Path;
 use duct::{cmd, Expression};
@@ -46,10 +45,11 @@ pub fn rustup_target_add_for_checkers(targets: &[&str]) -> Result<()> {
     };
 
     // FIXME: use Cow for non +nightly host toolchain?
-    install_targets(PLUS_TOOLCHAIN_HOST)?;
+    install_targets(super::PLUS_TOOLCHAIN_HOST)?;
 
-    install_targets(PLUS_TOOLCHAIN_LOCKBUD)?;
-    install_targets(PLUS_TOOLCHAIN_MIRAI)?;
+    install_targets(super::PLUS_TOOLCHAIN_LOCKBUD)?;
+    install_targets(super::PLUS_TOOLCHAIN_MIRAI)?;
+    install_targets(super::PLUS_TOOLCHAIN_RAP)?;
 
     Ok(())
 }

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -23,10 +23,11 @@ pub fn install_toolchain(dir: &Utf8Path) -> Result<Vec<u8>> {
 }
 
 pub fn rustup_target_add(targets: &[&str], dir: &Utf8Path) -> Result<()> {
-    run_cmd(
-        cmd("rustup", ["target", "add"].iter().chain(targets)).dir(dir),
-        || format!("在 {dir:?} 目录下安装如下 targets {targets:?} 失败"),
-    )
+    let expr = cmd("rustup", ["target", "add"].iter().chain(targets)).dir(dir);
+    info!(?expr, ?targets, %dir);
+    run_cmd(expr, || {
+        format!("在 {dir:?} 目录下安装如下 targets {targets:?} 失败")
+    })
 }
 
 #[instrument(level = "info")]

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -41,7 +41,9 @@ pub fn rustup_target_add_for_checkers(targets: &[&str]) -> Result<()> {
 
     let mut install_targets = move |toolchain: &'static str| {
         args[0] = toolchain;
-        run_cmd(cmd("rustup", &args), || err(toolchain))
+        let expr = cmd("rustup", &args);
+        info!(?expr);
+        run_cmd(expr, || err(toolchain))
     };
 
     // FIXME: use Cow for non +nightly host toolchain?

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -42,7 +42,6 @@ pub fn rustup_target_add_for_checkers(targets: &[&str]) -> Result<()> {
     let mut install_targets = move |toolchain: &'static str| {
         args[0] = toolchain;
         let expr = cmd("rustup", &args);
-        info!(?expr);
         run_cmd(expr, || err(toolchain))
     };
 


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/216

此 PR 还增加了 `FORCE_RUN_CHECK` 环境变量，设置为 true 时，表示下载仓库之后，不读取缓存，直接运行检查命令；默认为 false，表示下载仓库后，查看缓存再决定是否运行检查命令。

如果不要安装某个 target，应把它放入配置文件的 no_install_targets 字段。