### PR TITLE
feat: 支持对检查命令设置环境变量

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,8 +27,8 @@ env:
   # force running checks after downloading repos
   FORCE_RUN_CHECK: false
   # use which configs
-  OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,7 +25,7 @@ env:
   # force downloading repos to run check 
   FORCE_REPO_CHECK: true
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: false
+  FORCE_RUN_CHECK: true
   # use which configs
   OS_CHECKER_CONFIGS: repos.json # for debug single repo
   # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -21,7 +21,7 @@ env:
   # push to which database branch 
   DATABASE: main
   # cache.redb tag in database release
-  TAG_CACHE: cache-v12.redb
+  TAG_CACHE: cache-v11.redb
   # force downloading repos to run check 
   FORCE_REPO_CHECK: false
   # force running checks after downloading repos

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,7 +25,7 @@ env:
   # force downloading repos to run check 
   FORCE_REPO_CHECK: true
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: true
+  FORCE_RUN_CHECK: false
   # use which configs
   OS_CHECKER_CONFIGS: repos.json # for debug single repo
   # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,16 +19,16 @@ env:
   PUSH: true
   toolchain: nightly-2024-12-26
   # push to which database branch 
-  DATABASE: main
+  DATABASE: debug
   # cache.redb tag in database release
-  TAG_CACHE: cache-v11.redb
+  TAG_CACHE: cache-v12.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: false
+  FORCE_RUN_CHECK: true
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -21,7 +21,7 @@ env:
   # push to which database branch 
   DATABASE: main
   # cache.redb tag in database release
-  TAG_CACHE: cache-v11.redb
+  TAG_CACHE: cache-v12.redb
   # force downloading repos to run check 
   FORCE_REPO_CHECK: false
   # force running checks after downloading repos

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,9 +23,9 @@ env:
   # cache.redb tag in database release
   TAG_CACHE: cache-v12.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: true
+  FORCE_RUN_CHECK: false
   # use which configs
   OS_CHECKER_CONFIGS: repos.json # for debug single repo
   # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,8 +1,20 @@
 {
   "shilei-massclouds/mmap": {
-    "env": {
-      "AX_ARCH": "riscv64",
-      "AX_PLATFORM": "riscv64-qemu-virt"
+    "meta": {
+      "target_env": {
+        "riscv64gc-unknown-none-elf": {
+          "AX_ARCH": "riscv64",
+          "AX_PLATFORM": "riscv64-qemu-virt"
+        },
+        "aarch64-unknown-none-softfloat": {
+          "AX_ARCH": "aarch64",
+          "AX_PLATFORM": "aarch64-qemu-virt"
+        },
+        "x86_64-unknown-none": {
+          "AX_ARCH": "x86_64",
+          "AX_PLATFORM": "x86-pc"
+        }
+      }
     }
   }
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,9 +1,8 @@
 {
-  "qclic/sparreal-os": {
-    "packages": {
-      "xtask": {
-        "targets": "x86_64-unknown-linux-gnu"
-      }
+  "shilei-massclouds/mmap": {
+    "env": {
+      "AX_ARCH": "riscv64",
+      "AX_PLATFORM": "riscv64-qemu-virt"
     }
   }
 }

--- a/os-checker-types/src/cache.rs
+++ b/os-checker-types/src/cache.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use std::hash::Hash;
 
 // 由于我们想对每个检查出了结果时缓存，而不是在仓库所有检查完成时缓存，这里需要重复数据。
 // 减少数据重复，需要新定义一个结构，在缓存和 PackagesOutputs 上。
@@ -52,18 +53,66 @@ pub struct CacheChecker {
     pub sha: Option<String>,
 }
 
-#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Encode, Decode, Clone, PartialEq, Eq)]
 pub struct CacheCmd {
     pub cmd: String,
     pub target: String,
     /// FIXME: channel 转换回 RustToolchain 会丢失额外的信息
     pub channel: String,
+    #[musli(with = musli::serde)]
+    pub env: IndexMap<String, String>,
     // Below is not necessary, and currently not implemented.
     #[musli(with = musli::serde)]
     pub features: Vec<XString>,
     /// rustcflags
     #[musli(with = musli::serde)]
     pub flags: Vec<XString>,
+}
+
+impl PartialOrd for CacheCmd {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for CacheCmd {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let Self {
+            cmd,
+            target,
+            channel,
+            env,
+            features,
+            flags,
+        } = self;
+        let a = (cmd, target, channel, env.as_slice(), features, flags);
+        let Self {
+            cmd,
+            target,
+            channel,
+            env,
+            features,
+            flags,
+        } = other;
+        let b = (cmd, target, channel, env.as_slice(), features, flags);
+        a.cmp(&b)
+    }
+}
+impl Hash for CacheCmd {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: std::hash::Hasher,
+    {
+        let Self {
+            cmd,
+            target,
+            channel,
+            env,
+            features,
+            flags,
+        } = self;
+        let a = (cmd, target, channel, env.as_slice(), features, flags);
+        a.hash(state);
+    }
 }
 
 #[derive(Encode, Decode)]

--- a/os-checker-types/src/config.rs
+++ b/os-checker-types/src/config.rs
@@ -7,6 +7,8 @@ pub struct RepoConfig {
     pub targets: Option<Targets>,
     pub no_install_targets: Option<Targets>,
     #[musli(with = musli::serde)]
+    pub env: Option<IndexMap<String, String>>,
+    #[musli(with = musli::serde)]
     pub cmds: Cmds,
     #[musli(with = musli::serde)]
     pub packages: IndexMap<String, RepoConfig>,

--- a/os-checker-types/src/config.rs
+++ b/os-checker-types/src/config.rs
@@ -66,4 +66,20 @@ impl Cmds {
 #[derive(Debug, Serialize, Deserialize, Encode, Decode, Clone)]
 pub struct Meta {
     pub skip_pkg_dir_globs: MaybeMulti,
+    /// { "target1": { "ENV1": "val" } }
+    #[serde(default)]
+    #[musli(with = musli::serde)]
+    pub target_env: TargetEnv,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(transparent)]
+pub struct TargetEnv {
+    pub map: IndexMap<String, Env>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(transparent)]
+pub struct Env {
+    pub map: IndexMap<String, String>,
 }

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -11,14 +11,12 @@ use duct::{cmd, Expression};
 use indexmap::IndexMap;
 use yash_syntax::syntax::{SimpleCommand, Unquote, Value};
 
-fn add_env(mut expr: Expression, env: Option<&IndexMap<String, String>>) -> (Expression, String) {
+fn add_env(mut expr: Expression, env: &IndexMap<String, String>) -> (Expression, String) {
     use std::fmt::Write;
     let mut env_str = String::new();
-    if let Some(vars) = env {
-        for (name, val) in vars {
-            expr = expr.env(name, val);
-            _ = write!(env_str, "{name}={val:?} ");
-        }
+    for (name, val) in env {
+        expr = expr.env(name, val);
+        _ = write!(env_str, "{name}={val:?} ");
     }
     (expr, env_str)
 }
@@ -37,7 +35,7 @@ fn add_env(mut expr: Expression, env: Option<&IndexMap<String, String>>) -> (Exp
 pub fn cargo_fmt(pkg: &Pkg) -> Resolve {
     let toolchain = host_toolchain();
     let expr = cmd!("cargo", &toolchain, "fmt", "--", "--emit=json").dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!("{env_str}cargo {toolchain} fmt -- --emit=json");
     Resolve::new(pkg, CheckerTool::Fmt, cmd, expr)
@@ -56,7 +54,7 @@ pub fn cargo_clippy(pkg: &Pkg) -> Resolve {
         "--message-format=json"
     )
     .dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!("{env_str}cargo clippy --target {target} --no-deps --message-format=json");
     Resolve::new(pkg, CheckerTool::Clippy, cmd, expr)
@@ -85,7 +83,7 @@ pub fn cargo_lockbud(pkg: &Pkg) -> Resolve {
         // &lockbud_dir
     )
     .dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd =
         format!("{env_str}cargo {PLUS_TOOLCHAIN_LOCKBUD} lockbud -k all -- --target {target}");
@@ -105,7 +103,7 @@ pub fn cargo_mirai(pkg: &Pkg) -> Resolve {
         "--message-format=json"
     )
     .dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!(
         "{env_str}cargo {PLUS_TOOLCHAIN_MIRAI} mirai --target {target} --message-format=json"
@@ -128,7 +126,7 @@ pub fn cargo_rap(pkg: &Pkg) -> Resolve {
     )
     .env("RAP_LOG", "WARN")
     .dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!("{env_str}cargo {PLUS_TOOLCHAIN_RAP} rap -F -M -- --target {target}");
     Resolve::new(pkg, CheckerTool::Rap, cmd, expr)
@@ -137,7 +135,7 @@ pub fn cargo_rap(pkg: &Pkg) -> Resolve {
 // FIXME: check how cargo check arguments are supported by rudra
 pub fn cargo_rudra(pkg: &Pkg) -> Resolve {
     let expr = cmd!("cargo", PLUS_TOOLCHAIN_RUDRA, "rudra",).dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!("{env_str}cargo {PLUS_TOOLCHAIN_RUDRA} rudra");
     Resolve::new(pkg, CheckerTool::Rudra, cmd, expr)
@@ -155,7 +153,7 @@ pub fn cargo_geiger(pkg: &Pkg) -> Resolve {
         "never",
     )
     .dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!("{env_str}cargo {toolchain} geiger --output-format Ascii");
     Resolve::new(pkg, CheckerTool::Geiger, cmd, expr)
@@ -172,7 +170,7 @@ pub fn cargo_outdated(pkg: &Pkg) -> Resolve {
         "--color=never"
     )
     .dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!("{env_str}cargo {toolchain} outdated -R --exit-code=2");
     Resolve::new(pkg, CheckerTool::Outdated, cmd, expr)
@@ -189,7 +187,7 @@ pub fn cargo_semver_checks(pkg: &Pkg) -> Resolve {
         "--color=never"
     )
     .dir(pkg.dir);
-    let (expr, env_str) = add_env(expr, pkg.env);
+    let (expr, env_str) = add_env(expr, &pkg.env);
     debug!(?expr);
     let cmd = format!(
         "{env_str}cargo {toolchain} semver-checks --target {}",

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -36,11 +36,10 @@ fn add_env(mut expr: Expression, env: Option<&IndexMap<String, String>>) -> (Exp
 // For more information, try '--help'.
 pub fn cargo_fmt(pkg: &Pkg) -> Resolve {
     let toolchain = host_toolchain();
-    let name = pkg.name;
-    let expr = cmd!("cargo", &toolchain, "fmt", "-p", name, "--", "--emit=json").dir(pkg.dir);
+    let expr = cmd!("cargo", &toolchain, "fmt", "--", "--emit=json").dir(pkg.dir);
     let (expr, env_str) = add_env(expr, pkg.env);
     debug!(?expr);
-    let cmd = format!("{env_str}cargo {toolchain} fmt -p {name} -- --emit=json");
+    let cmd = format!("{env_str}cargo {toolchain} fmt -- --emit=json");
     Resolve::new(pkg, CheckerTool::Fmt, cmd, expr)
 }
 

--- a/src/config/cmd/tests.rs
+++ b/src/config/cmd/tests.rs
@@ -65,6 +65,7 @@ fn custom_cmd() {
         dir: cargo_metadata::camino::Utf8Path::new("."),
         target: "x86_64-unknown-linux-gnu",
         toolchain: Some(0),
+        env: None,
         audit: None,
         is_lib: true,
     };

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -34,6 +34,8 @@ pub struct RepoConfig {
     /// 暂时只作用于 repo
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_install_targets: Option<Targets>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<IndexMap<String, String>>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Cmds::is_empty")]
     pub cmds: Cmds,

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -75,7 +75,7 @@ impl RepoConfig {
             };
 
             // if targets is empty, pick candidates detected from repo
-            let pkgs = info.pkgs(pkg_name, targets);
+            let pkgs = info.pkgs(pkg_name, targets, self.env.as_ref());
 
             resolve_for_single_pkg(&cmds, &pkgs, &mut v)?;
 

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -15,6 +15,7 @@ use std::fmt::Debug;
 mod tests;
 
 mod config_options;
+pub use config_options::TargetEnv;
 use config_options::{Cmds, Meta, Setup, Targets};
 
 mod misc;
@@ -75,7 +76,12 @@ impl RepoConfig {
             };
 
             // if targets is empty, pick candidates detected from repo
-            let pkgs = info.pkgs(pkg_name, targets, self.env.as_ref());
+            let pkgs = info.pkgs(
+                pkg_name,
+                targets,
+                self.env.as_ref(),
+                self.meta.as_ref().map(|m| &m.target_env),
+            );
 
             resolve_for_single_pkg(&cmds, &pkgs, &mut v)?;
 

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -183,13 +183,28 @@ pub struct Meta {
     skip_pkg_dir_globs: MaybeMulti,
     /// { "target1": { "ENV1": "val" } }
     #[serde(default)]
-    target_env: TargetEnv,
+    pub target_env: TargetEnv,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Default)]
 #[serde(transparent)]
-struct TargetEnv {
+pub struct TargetEnv {
     map: IndexMap<String, Env>,
+}
+
+impl TargetEnv {
+    pub fn merge(
+        &self,
+        target: &str,
+        global: &IndexMap<String, String>,
+    ) -> IndexMap<String, String> {
+        let mut map = global.clone();
+        if let Some(env) = self.map.get(target) {
+            // override env if exists
+            map.extend(env.map.clone());
+        }
+        map
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -181,6 +181,21 @@ impl std::ops::DerefMut for Cmds {
 pub struct Meta {
     #[serde(default = "defalt_skip_pkg_dir_globs")]
     skip_pkg_dir_globs: MaybeMulti,
+    /// { "target1": { "ENV1": "val" } }
+    #[serde(default)]
+    target_env: TargetEnv,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Default)]
+#[serde(transparent)]
+struct TargetEnv {
+    map: IndexMap<String, Env>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+#[serde(transparent)]
+struct Env {
+    map: IndexMap<String, String>,
 }
 
 impl Meta {
@@ -212,6 +227,21 @@ impl Default for Meta {
     fn default() -> Self {
         Self {
             skip_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
+            target_env: TargetEnv::default(),
         }
     }
+}
+
+#[test]
+fn target_env() {
+    let s = r#"
+{
+  "target_env": {
+    "target1": { "ENV1": "val" },
+    "target2": { "ENV2": "val", "ENV3": "val" }
+  }
+}"#;
+
+    let meta: Meta = serde_json::from_str(s).unwrap();
+    dbg!(&meta);
 }

--- a/src/config/deserialization/config_options/type_conversion.rs
+++ b/src/config/deserialization/config_options/type_conversion.rs
@@ -1,4 +1,4 @@
-use super::{Cmds, Meta, Setup, Targets};
+use super::{Cmds, Env, Meta, Setup, TargetEnv, Targets};
 use os_checker_types::config as out;
 
 // ********** CLI => os_checker_types **********
@@ -29,10 +29,28 @@ impl From<Cmds> for out::Cmds {
 
 impl From<Meta> for out::Meta {
     fn from(value: Meta) -> Self {
-        let Meta { skip_pkg_dir_globs } = value;
+        let Meta {
+            skip_pkg_dir_globs,
+            target_env,
+        } = value;
         Self {
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
+            target_env: target_env.into(),
         }
+    }
+}
+
+impl From<TargetEnv> for out::TargetEnv {
+    fn from(value: TargetEnv) -> Self {
+        out::TargetEnv {
+            map: value.map.into_iter().map(|(k, v)| (k, v.into())).collect(),
+        }
+    }
+}
+
+impl From<Env> for out::Env {
+    fn from(value: Env) -> Self {
+        out::Env { map: value.map }
     }
 }
 
@@ -64,9 +82,27 @@ impl From<out::Cmds> for Cmds {
 
 impl From<out::Meta> for Meta {
     fn from(value: out::Meta) -> Self {
-        let out::Meta { skip_pkg_dir_globs } = value;
+        let out::Meta {
+            skip_pkg_dir_globs,
+            target_env,
+        } = value;
         Self {
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
+            target_env: target_env.into(),
         }
+    }
+}
+
+impl From<out::TargetEnv> for TargetEnv {
+    fn from(value: out::TargetEnv) -> Self {
+        TargetEnv {
+            map: value.map.into_iter().map(|(k, v)| (k, v.into())).collect(),
+        }
+    }
+}
+
+impl From<out::Env> for Env {
+    fn from(value: out::Env) -> Self {
+        Env { map: value.map }
     }
 }

--- a/src/config/deserialization/type_conversion.rs
+++ b/src/config/deserialization/type_conversion.rs
@@ -13,6 +13,7 @@ impl From<RepoConfig> for out::RepoConfig {
             setup,
             targets,
             no_install_targets,
+            env,
             cmds,
             packages,
         } = value;
@@ -21,6 +22,7 @@ impl From<RepoConfig> for out::RepoConfig {
             setup: setup.map(|s| s.into()),
             targets: targets.map(|t| t.into()),
             no_install_targets: no_install_targets.map(|t| t.into()),
+            env,
             cmds: cmds.into(),
             packages: packages.into_iter().map(|(k, v)| (k, v.into())).collect(),
         }
@@ -55,6 +57,7 @@ impl From<out::RepoConfig> for RepoConfig {
             setup,
             targets,
             no_install_targets,
+            env,
             cmds,
             packages,
         } = value;
@@ -63,6 +66,7 @@ impl From<out::RepoConfig> for RepoConfig {
             setup: setup.map(|s| s.into()),
             targets: targets.map(|t| t.into()),
             no_install_targets: no_install_targets.map(|t| t.into()),
+            env,
             cmds: cmds.into(),
             packages: packages.into_iter().map(|(k, v)| (k, v.into())).collect(),
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,7 +23,7 @@ mod checker;
 pub use checker::{CheckerTool, TOOLS};
 
 mod deserialization;
-pub use deserialization::{gen_schema, RepoConfig, TargetsSpecifed};
+pub use deserialization::{gen_schema, RepoConfig, TargetEnv, TargetsSpecifed};
 
 #[cfg(test)]
 mod tests;

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use cargo_metadata::camino::Utf8PathBuf;
 use duct::Expression;
+use indexmap::IndexMap;
 
 /// 一个 package 待运行的检查命令（含 package 和 target triple）
 #[derive(Debug)]
@@ -24,6 +25,7 @@ pub struct Resolve {
     pub target: String,
     /// 仅当自定义检查命令出现 --target 时为 true
     pub target_overridden: bool,
+    pub env: IndexMap<String, String>,
     pub toolchain: Option<usize>,
     pub checker: CheckerTool,
     /// 完整的检查命令字符串（一定包含 --target）：
@@ -44,6 +46,7 @@ impl Resolve {
             target: pkg.target.to_owned(),
             target_overridden: false,
             toolchain: pkg.toolchain,
+            env: pkg.env.clone(),
             checker,
             cmd,
             expr,
@@ -65,6 +68,7 @@ impl Resolve {
             target,
             target_overridden: true,
             toolchain: pkg.toolchain,
+            env: pkg.env.clone(),
             checker,
             cmd,
             expr,
@@ -80,6 +84,7 @@ impl Resolve {
             target: self.target.clone(),
             target_overridden: self.target_overridden, // 无实际含义
             toolchain: self.toolchain,
+            env: IndexMap::default(),
             checker: CheckerTool::Cargo,
             cmd: format!("VRITUAL={} cargo", self.checker.name()),
             expr: duct::cmd!("false"), // 无实际含义
@@ -95,6 +100,7 @@ impl Resolve {
             target: host_target_triple().to_owned(),
             target_overridden: false, // 无实际含义
             toolchain: None,
+            env: IndexMap::default(),
             checker: CheckerTool::Cargo,
             cmd: "VRITUAL=LayoutParseError cargo".to_owned(),
             expr: duct::cmd!("false"), // 无实际含义

--- a/src/db/cache/mod.rs
+++ b/src/db/cache/mod.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use duct::cmd;
+use indexmap::IndexMap;
 use os_checker_types::db as out;
 use std::fmt;
 
@@ -32,6 +33,7 @@ impl CacheRepoKeyCmd {
                 cmd: resolve.cmd.clone(),
                 target: resolve.target.clone(),
                 channel: get_channel(resolve.toolchain.unwrap_or(0)),
+                env: resolve.env.clone(),
                 // TODO: 待支持
                 features: vec![],
                 flags: vec![],
@@ -122,6 +124,7 @@ struct CacheCmd {
     target: String,
     /// FIXME: channel 转换回 RustToolchain 会丢失额外的信息
     channel: String,
+    env: IndexMap<String, String>,
     // Below is not necessary, and currently not implemented.
     features: Vec<XString>,
     /// rustcflags

--- a/src/db/cache/type_conversion.rs
+++ b/src/db/cache/type_conversion.rs
@@ -70,6 +70,7 @@ impl From<CacheCmd> for out::CacheCmd {
             cmd,
             target,
             channel,
+            env,
             features,
             flags,
         } = value;
@@ -77,6 +78,7 @@ impl From<CacheCmd> for out::CacheCmd {
             cmd,
             target,
             channel,
+            env,
             features,
             flags,
         }
@@ -219,6 +221,7 @@ impl From<out::CacheCmd> for CacheCmd {
             cmd,
             target,
             channel,
+            env,
             features,
             flags,
         } = value;
@@ -226,6 +229,7 @@ impl From<out::CacheCmd> for CacheCmd {
             cmd,
             target,
             channel,
+            env,
             features,
             flags,
         }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -448,7 +448,12 @@ pub struct PackageInfoShared {
 }
 
 impl PackageInfoShared {
-    pub fn pkgs<'a>(&'a self, name: &'a str, targets: Option<&'a [String]>) -> Vec<Pkg<'a>> {
+    pub fn pkgs<'a>(
+        &'a self,
+        name: &'a str,
+        targets: Option<&'a [String]>,
+        env: Option<&'a IndexMap<String, String>>,
+    ) -> Vec<Pkg<'a>> {
         targets
             .unwrap_or(&self.targets)
             .iter()
@@ -457,6 +462,7 @@ impl PackageInfoShared {
                 dir: &self.pkg_dir,
                 target,
                 toolchain: self.toolchain,
+                env,
                 audit: self.audit.as_ref(),
                 is_lib: self.is_lib,
             })
@@ -474,6 +480,7 @@ pub struct Pkg<'a> {
     pub dir: &'a Utf8Path,
     pub target: &'a str,
     pub toolchain: Option<usize>,
+    pub env: Option<&'a IndexMap<String, String>>,
     pub audit: Option<&'a Rc<CargoAudit>>,
     pub is_lib: bool,
 }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -1,7 +1,7 @@
 //! 启发式了解项目的 Rust packages 组织结构。
 
 use crate::{
-    config::{Resolve, TargetsSpecifed},
+    config::{Resolve, TargetEnv, TargetsSpecifed},
     db::out::{CacheLayout, CachePackageInfo, CacheResolve, CargoMetaData},
     output::{get_channel, install_toolchain_idx, remove_targets, uninstall_toolchains},
     run_checker::DbRepo,
@@ -453,6 +453,7 @@ impl PackageInfoShared {
         name: &'a str,
         targets: Option<&'a [String]>,
         env: Option<&'a IndexMap<String, String>>,
+        target_env: Option<&TargetEnv>,
     ) -> Vec<Pkg<'a>> {
         targets
             .unwrap_or(&self.targets)
@@ -462,7 +463,12 @@ impl PackageInfoShared {
                 dir: &self.pkg_dir,
                 target,
                 toolchain: self.toolchain,
-                env,
+                env: match (env, target_env) {
+                    (None, None) => IndexMap::default(),
+                    (None, Some(t)) => t.merge(target, &IndexMap::default()),
+                    (Some(g), None) => g.clone(),
+                    (Some(g), Some(t)) => t.merge(target, g),
+                },
                 audit: self.audit.as_ref(),
                 is_lib: self.is_lib,
             })
@@ -480,7 +486,7 @@ pub struct Pkg<'a> {
     pub dir: &'a Utf8Path,
     pub target: &'a str,
     pub toolchain: Option<usize>,
-    pub env: Option<&'a IndexMap<String, String>>,
+    pub env: IndexMap<String, String>,
     pub audit: Option<&'a Rc<CargoAudit>>,
     pub is_lib: bool,
 }


### PR DESCRIPTION
* close https://github.com/os-checker/os-checker/issues/242 （暂不准备实现 2 和 4）
* 解决一部分 https://github.com/os-checker/os-checker/issues/197#issuecomment-2564332096

## 1. 仓库级别的环境变量作用于所有成员库的所有检查命令

```json
{
  "user/repo": { "env": {"ENV1": "val1", "ENV2": "val2"} }
}
```

## 3. 与 target 交互，则放到 `meta.target_env`

```json
"meta": {
  "target_env": {
    "target1": { "ENV1": "val" },
    "target2": { "ENV2": "val" }
  }
}
```

当环境变量重复时，3 覆盖 1。

环境变量被放入命令的缓存键中。