### PR TITLE
feat: 发布 v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v0.5.0
+
+Features
+
+* feat: cargo 诊断增加时间戳；rap 在检测到的 targets 上运行 ([#234](https://github.com/os-checker/os-checker/pull/234))
+* feat: 增加配置文件指定的 target 源 ([#239](https://github.com/os-checker/os-checker/pull/239))
+* feat: 支持对检查命令设置环境变量 ([#244](https://github.com/os-checker/os-checker/pull/244))
+
+Fixes
+
+* fix: ALL_TARGETS 通过的仓库计数 ([#236](https://github.com/os-checker/os-checker/pull/236))
+* fix: layout 子命令应输出到文件而不是 stdout ([#247](https://github.com/os-checker/os-checker/pull/247))
+* fix: 一旦启发式地找到确定的 target，不要默认添加 x86_64-unknown-linux-gnu ([#233](https://github.com/os-checker/os-checker/pull/233))
+* fix: 在仓库和 package 中指定的 targets 应追加到安装列表，而不是覆盖安装列表 ([#238](https://github.com/os-checker/os-checker/pull/238))
+* fix: 运行 rap 时指定 --target 参数 ([#231](https://github.com/os-checker/os-checker/pull/231))
+
 # v0.4.2
 
 添加 `config` 子命令和 `--merged`、`--list-repos` 参数。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os-checker"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "argh",
  "basic-toml",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "os-checker-database"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "camino",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "os-checker-types"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "camino",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-checker"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"
@@ -85,7 +85,7 @@ redb = "2"
 musli = { version = "0.0.124", features = ["storage", "serde"] }
 time = { version = "0.3", features = ["parsing", "macros"] }
 
-os-checker-types = { version = "0.4.0", path = "os-checker-types" }
+os-checker-types = { version = "0.5.0", path = "os-checker-types" }
 
 cargo_metadata = "0.18.1" # parse metadata for knowing project layout
 # [workspace.dependencies.cargo_metadata]

--- a/os-checker-database/Cargo.toml
+++ b/os-checker-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-checker-database"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"

--- a/os-checker-types/Cargo.toml
+++ b/os-checker-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-checker-types"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 rust-version = "1.80"


### PR DESCRIPTION
Features

* feat: cargo 诊断增加时间戳；rap 在检测到的 targets 上运行 ([#234](https://github.com/os-checker/os-checker/pull/234))
* feat: 增加配置文件指定的 target 源 ([#239](https://github.com/os-checker/os-checker/pull/239))
* feat: 支持对检查命令设置环境变量 ([#244](https://github.com/os-checker/os-checker/pull/244))

Fixes

* fix: ALL_TARGETS 通过的仓库计数 ([#236](https://github.com/os-checker/os-checker/pull/236))
* fix: layout 子命令应输出到文件而不是 stdout ([#247](https://github.com/os-checker/os-checker/pull/247))
* fix: 一旦启发式地找到确定的 target，不要默认添加 x86_64-unknown-linux-gnu ([#233](https://github.com/os-checker/os-checker/pull/233))
* fix: 在仓库和 package 中指定的 targets 应追加到安装列表，而不是覆盖安装列表 ([#238](https://github.com/os-checker/os-checker/pull/238))
* fix: 运行 rap 时指定 --target 参数 ([#231](https://github.com/os-checker/os-checker/pull/231))