### PR TITLE
ci: check ZR233/ostool with libudev-dev installed

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,16 +19,16 @@ env:
   PUSH: true
   toolchain: nightly-2024-12-26
   # push to which database branch 
-  DATABASE: main
+  DATABASE: debug
   # cache.redb tag in database release
   TAG_CACHE: cache-v12.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: false
+  FORCE_RUN_CHECK: true
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:
@@ -71,6 +71,10 @@ jobs:
           rustup default nightly-2024-10-05 && cargo lockbud --help
           rustup default nightly-2024-10-12 && cargo rap --help
           rustup default ${{ env.toolchain }}
+
+      - name: Extra building environment required by OS libs
+        run: |
+          sudo apt install libudev-dev -y # ZR233/ostool requires
 
       - name: Install os-checker
         run: cargo install --path . --force

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,20 +1,3 @@
 {
-  "shilei-massclouds/mmap": {
-    "meta": {
-      "target_env": {
-        "riscv64gc-unknown-none-elf": {
-          "AX_ARCH": "riscv64",
-          "AX_PLATFORM": "riscv64-qemu-virt"
-        },
-        "aarch64-unknown-none-softfloat": {
-          "AX_ARCH": "aarch64",
-          "AX_PLATFORM": "aarch64-qemu-virt"
-        },
-        "x86_64-unknown-none": {
-          "AX_ARCH": "x86_64",
-          "AX_PLATFORM": "x86-pc"
-        }
-      }
-    }
-  }
+  "ZR233/ostool": {}
 }


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/220

修复结果：

![image](https://github.com/user-attachments/assets/5b8b6dad-3656-41f0-87a2-72e7a052f0f7)


给 ostool 的仓库提交了诊断修复： https://github.com/ZR233/ostool/pull/1 ，诊断变成

![截图_20250102222107](https://github.com/user-attachments/assets/c1275e89-84bf-49d4-9051-6a5448009f02)

由于缺乏变量信息，暂时无法排查具体是什么问题（打开 https://github.com/os-checker/os-checker/issues/252 ）