### PR TITLE
ci: install libfuse-dev fuse3 libfuse3-dev for yuoo655/ext4libtest

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Extra building environment required by OS libs
         run: |
           sudo apt install libudev-dev -y # ZR233/ostool requires
+          sudo apt install libfuse-dev fuse3 libfuse3-dev -y # yuoo655/ext4libtest requires
 
       - name: Install os-checker
         run: cargo install --path . --force

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,3 @@
 {
-  "ZR233/ostool": {}
+  "yuoo655/ext4libtest": {}
 }


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/218

安装 fuse 环境之后的检查结果：

![截图_20250103134449](https://github.com/user-attachments/assets/e6630e0a-5af1-4336-bffe-8b5083023a67)

在测试情况上：（添加到 https://github.com/os-checker/os-checker/issues/253 ）
* 一个单元测试正常运行并通过（但需要运行 gen_img.sh 生成文件镜像为测试做准备）；
* 还有一个是集成测试，需要两个终端才能测试（或者需要一个自动化测试流程来替代人工测试）。

向 yuoo655/ext4libtest 提交诊断修复，见： https://github.com/yuoo655/ext4libtest/pull/1