### PR TITLE
feat: update semver-checks to support v39 rustdoc JSON format

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,7 +23,7 @@ env:
   # cache.redb tag in database release
   TAG_CACHE: cache-v14.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # force running checks after downloading repos
   FORCE_RUN_CHECK: false
   # use which configs

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,16 +19,16 @@ env:
   PUSH: true
   toolchain: nightly-2025-01-26
   # push to which database branch 
-  DATABASE: main
+  DATABASE: debug
   # cache.redb tag in database release
   TAG_CACHE: cache-v14.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: false
+  FORCE_RUN_CHECK: true
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,8 +27,8 @@ env:
   # force running checks after downloading repos
   FORCE_RUN_CHECK: false
   # use which configs
-  OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,7 +19,7 @@ env:
   PUSH: true
   toolchain: nightly-2025-01-26
   # push to which database branch 
-  DATABASE: debug
+  DATABASE: main
   # cache.redb tag in database release
   TAG_CACHE: cache-v14.redb
   # force downloading repos to run check 
@@ -95,7 +95,7 @@ jobs:
 
           # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
-          batch --size 2 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          batch --size 16 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
 
           os-checker db --done cache.redb
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,7 +25,7 @@ env:
   # force downloading repos to run check 
   FORCE_REPO_CHECK: true
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: true
+  FORCE_RUN_CHECK: false
   # use which configs
   OS_CHECKER_CONFIGS: repos.json # for debug single repo
   # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,12 +1,3 @@
 {
-  "qclic/sparreal-os": {},
-  "guoweikang/osl": {
-    "packages": {
-      "osl": {
-        "features": [
-          "arceos"
-        ]
-      }
-    }
-  }
+  "Azure-stars/kernel_elf_parser": {}
 }

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -370,9 +370,8 @@ fn run_check(
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
     // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
-    if !utils::force_run_check() && !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo)
-    {
-        // if !utils::force_run_check() && outputs.fetch_cache(&resolve, db_repo) {
+    // if !utils::force_run_check() && !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo)    {
+    if !utils::force_run_check() && outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -370,8 +370,9 @@ fn run_check(
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
     // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
-    // if !utils::force_run_check() && !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
-    if !utils::force_run_check() && outputs.fetch_cache(&resolve, db_repo) {
+    if !utils::force_run_check() && !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo)
+    {
+        // if !utils::force_run_check() && outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/293

修复前： `error: unsupported rustdoc format v39 for file`
![截图_20250307194658](https://github.com/user-attachments/assets/229fc74c-72f3-436c-8d54-035495eb05d8)

修复后：
![截图_20250307194611](https://github.com/user-attachments/assets/c12413f6-7c42-4cfb-b1a8-226269b995e9)
