### PR TITLE
Feat: add `run --no-layout-error` and JSON input's `meta.only_pkg_dir_globs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "shlex",
 ]
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -444,9 +444,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1191,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
+checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1353,25 +1353,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tracing"
@@ -1753,9 +1760,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ strip-ansi-escapes = "0.2"
 jsonxf = "1"
 # wait for https://github.com/gamache/jsonxf/pull/10 to merge
 # jsonxf = {git="https://github.com/os-checker/jsonxf.git", branch="make-getopts-optional", default-features = false}
-rustsec = { version = "0.30.0-rc.0", default-features = false, features = ["dependency-tree"] }
+rustsec = { version = "0.30.2", default-features = false, features = ["dependency-tree"] }
 # replace_with = "0.1"
 
 # error handling

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -15,6 +15,9 @@ struct Batch {
     /// forward --size
     #[argh(option)]
     size: String,
+    /// don't upload the cache.redb to githhub
+    #[argh(switch)]
+    no_upload: bool,
 }
 
 const DB: &str = "cache.redb";
@@ -66,7 +69,9 @@ fn main() -> Result<()> {
             );
             info!(cmd = ?expr);
             expr.run()?;
-            upload_cache()?;
+            if !batch.no_upload {
+                upload_cache()?;
+            }
             count_json_file += 1;
             count_repos += repos.len();
         }

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -61,7 +61,8 @@ fn main() -> Result<()> {
                 "--emit",
                 emit.as_str(),
                 "--db",
-                DB
+                DB,
+                "--no-layout-error"
             );
             info!(cmd = ?expr);
             expr.run()?;

--- a/os-checker-database/Cargo.toml
+++ b/os-checker-database/Cargo.toml
@@ -38,7 +38,5 @@ musli = { workspace = true }
 
 [features]
 default = ["clear_batch"]
-single = []
-batch = []
 clear_batch = [] # 清除 BASE_DIR/batch 目录
 

--- a/os-checker-database/src/main.rs
+++ b/os-checker-database/src/main.rs
@@ -31,7 +31,6 @@ mod targets;
 
 mod db;
 
-#[cfg(any(feature = "batch", feature = "clear_batch"))]
 fn main() -> Result<()> {
     logger::init();
 
@@ -162,30 +161,6 @@ fn clear_base_dir() -> Result<()> {
         error!("{err:?}");
     }
     info!("清理 {BASE_DIR}");
-    Ok(())
-}
-
-#[cfg(feature = "single")]
-#[instrument(level = "trace")]
-fn main() -> Result<()> {
-    let json = read_json("ui.json")?;
-
-    clear_base_dir()?;
-
-    // Write basic JSON
-    write_to_file("", "basic", &basic::all(&json))?;
-    for (repo, b) in basic::by_repo(&json) {
-        write_to_file(&format!("repos/{}/{}", repo.user, repo.repo), "basic", &b)?;
-    }
-
-    // Write home JSON
-    write_to_file(HOME_DIR, ALL_TARGETS, &home::all_targets(&json))?;
-    for (target, nodes) in home::split_by_target(&json) {
-        write_to_file(HOME_DIR, target, &nodes)?;
-    }
-
-    write_filetree(&json)?;
-
     Ok(())
 }
 

--- a/os-checker-database/src/main.rs
+++ b/os-checker-database/src/main.rs
@@ -34,6 +34,7 @@ mod db;
 fn main() -> Result<()> {
     logger::init();
 
+    // Search all json in batch dir.
     let paths = json_paths("batch")?;
 
     clear_base_dir()?;

--- a/os-checker-types/src/config.rs
+++ b/os-checker-types/src/config.rs
@@ -89,6 +89,7 @@ impl Cmds {
 
 #[derive(Debug, Serialize, Deserialize, Encode, Decode, Clone)]
 pub struct Meta {
+    pub only_pkg_dir_globs: MaybeMulti,
     pub skip_pkg_dir_globs: MaybeMulti,
     /// { "target1": { "ENV1": "val" } }
     #[serde(default)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -127,7 +127,7 @@ struct ArgsLayout {
     #[argh(option)]
     base_dir: Option<Utf8PathBuf>,
     /// exit if any layout error happens
-    #[argh(option, default = "false")]
+    #[argh(switch)]
     no_layout_error: bool,
     /// display targets of packages for a given repos. The packages are filterred out as specified
     /// in the config.
@@ -162,7 +162,7 @@ pub struct ArgsRun {
     keep_repo: bool,
 
     /// exit if any layout error happens
-    #[argh(option, default = "false")]
+    #[argh(switch)]
     no_layout_error: bool,
 
     /// redb file path. If not specified, no cache for checking.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -161,6 +161,10 @@ pub struct ArgsRun {
     #[argh(switch)]
     keep_repo: bool,
 
+    /// exit if any layout error happens
+    #[argh(option, default = "false")]
+    no_layout_error: bool,
+
     /// redb file path. If not specified, no cache for checking.
     #[argh(option)]
     db: Option<Utf8PathBuf>,
@@ -293,6 +297,8 @@ fn repos_outputs(
 impl ArgsRun {
     #[instrument(level = "trace")]
     fn execute(&self) -> Result<()> {
+        NO_LAYOUT_ERROR.store(self.no_layout_error, Ordering::SeqCst);
+
         let db = self.db.as_deref().map(Db::new).transpose()?;
         let start = SystemTime::now();
         let outs = repos_outputs(&self.config, db.clone())?

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -212,6 +212,13 @@ impl RepoConfig {
             .unwrap_or_default()
     }
 
+    pub fn only_pkg_dir_globs(&self) -> Box<[glob::Pattern]> {
+        self.meta
+            .as_ref()
+            .map(|m| m.only_pkg_dir_globs())
+            .unwrap_or_default()
+    }
+
     /// 将 packages 按名称排序
     pub fn sort_packages(&mut self) {
         self.packages.sort_unstable_keys();

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -196,6 +196,8 @@ impl RepoConfig {
         if let Some(meta) = &self.meta {
             meta.check_skip_pkg_dir_globs()
                 .with_context(|| format!("{repo}'s meta.skip_pkg_dir_globs value is invalid."))?;
+            meta.check_only_pkg_dir_globs()
+                .with_context(|| format!("{repo}'s meta.only_pkg_dir_globs value is invalid."))?;
         }
         Ok(())
     }

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -183,6 +183,9 @@ impl std::ops::DerefMut for Cmds {
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct Meta {
     #[serde(default = "defalt_skip_pkg_dir_globs")]
+    only_pkg_dir_globs: MaybeMulti,
+
+    #[serde(default = "defalt_skip_pkg_dir_globs")]
     skip_pkg_dir_globs: MaybeMulti,
     /// { "target1": { "ENV1": "val" } }
     #[serde(default)]
@@ -217,6 +220,14 @@ struct Env {
 }
 
 impl Meta {
+    pub fn only_pkg_dir_globs(&self) -> Box<[glob::Pattern]> {
+        self.only_pkg_dir_globs
+            .as_slice()
+            .iter()
+            .filter_map(|s| glob_pattern(s).ok())
+            .collect()
+    }
+
     pub fn skip_pkg_dir_globs(&self) -> Box<[glob::Pattern]> {
         self.skip_pkg_dir_globs
             .as_slice()
@@ -244,6 +255,7 @@ fn defalt_skip_pkg_dir_globs() -> MaybeMulti {
 impl Default for Meta {
     fn default() -> Self {
         Self {
+            only_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
             skip_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
             target_env: TargetEnv::default(),
         }

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -228,6 +228,13 @@ impl Meta {
             .collect()
     }
 
+    pub fn check_only_pkg_dir_globs(&self) -> Result<()> {
+        for s in self.only_pkg_dir_globs.as_slice() {
+            glob_pattern(s)?;
+        }
+        Ok(())
+    }
+
     pub fn skip_pkg_dir_globs(&self) -> Box<[glob::Pattern]> {
         self.skip_pkg_dir_globs
             .as_slice()

--- a/src/config/deserialization/config_options/type_conversion.rs
+++ b/src/config/deserialization/config_options/type_conversion.rs
@@ -30,10 +30,12 @@ impl From<Cmds> for out::Cmds {
 impl From<Meta> for out::Meta {
     fn from(value: Meta) -> Self {
         let Meta {
+            only_pkg_dir_globs,
             skip_pkg_dir_globs,
             target_env,
         } = value;
         Self {
+            only_pkg_dir_globs: only_pkg_dir_globs.into(),
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
             target_env: target_env.into(),
         }
@@ -83,10 +85,12 @@ impl From<out::Cmds> for Cmds {
 impl From<out::Meta> for Meta {
     fn from(value: out::Meta) -> Self {
         let out::Meta {
+            only_pkg_dir_globs,
             skip_pkg_dir_globs,
             target_env,
         } = value;
         Self {
+            only_pkg_dir_globs: only_pkg_dir_globs.into(),
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
             target_env: target_env.into(),
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -106,6 +106,10 @@ impl Config {
             .collect())
     }
 
+    pub fn only_pkg_dir_globs(&self) -> Box<[glob::Pattern]> {
+        self.config.only_pkg_dir_globs()
+    }
+
     pub fn skip_pkg_dir_globs(&self) -> Box<[glob::Pattern]> {
         self.config.skip_pkg_dir_globs()
     }

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -142,7 +142,7 @@ pub fn scripts_and_github_dir_in_repo(repo_root: &Utf8Path) -> Result<Targets> {
     })?;
 
     let github_dir = Utf8Path::new(repo_root).join(".github");
-    let github_files = walk_dir(&github_dir, 4, empty(), Some);
+    let github_files = walk_dir(&github_dir, 4, empty(), &[], Some);
     debug!(%repo_root, ?github_files);
 
     scan_scripts_for_target(&github_files, |target, path| {
@@ -154,7 +154,7 @@ pub fn scripts_and_github_dir_in_repo(repo_root: &Utf8Path) -> Result<Targets> {
 }
 
 fn scripts_in_dir(dir: &Utf8Path, f: impl FnMut(&str, Utf8PathBuf)) -> Result<()> {
-    let scripts = walk_dir(dir, 4, [".github"], |file_path| {
+    let scripts = walk_dir(dir, 4, [".github"], &[], |file_path| {
         let file_stem = file_path.file_stem()?;
 
         if file_stem.starts_with("Makefile")

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -578,11 +578,16 @@ fn lib_pkgs(workspaces: &Workspaces) -> IndexMap<XString, PkgFeaturesLib> {
                     is_lib: false,
                 },
             );
-            assert!(
-                old.is_none(),
-                "Package `{}` already exists.\nOld={old:?}",
-                p.name
-            );
+            if no_layout_error() {
+                // solana-foundation/anchor: Package `crank` already exists.
+                error!("Package `{}` already exists.\nOld={old:?}", p.name);
+            } else {
+                assert!(
+                    old.is_none(),
+                    "Package `{}` already exists.\nOld={old:?}",
+                    p.name
+                );
+            }
             for target in &p.targets {
                 for kind in &target.kind {
                     if kind == "lib" {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -217,7 +217,20 @@ impl Layout {
         // 无论如何，这都带来复杂性，目前来看并不值得。
 
         let mut libs = lib_pkgs(&self.workspaces);
-        let audit = CargoAudit::new_for_pkgs(self.workspaces.keys())?;
+        let audit = {
+            let res = CargoAudit::new_for_pkgs(self.workspaces.keys());
+            match res {
+                Ok(audit) => audit,
+                Err(err) => {
+                    if no_layout_error() {
+                        error!(?err);
+                        Default::default()
+                    } else {
+                        return Err(err);
+                    }
+                }
+            }
+        };
 
         let map: IndexMap<_, _> = self
             .packages_info

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -223,7 +223,7 @@ impl Layout {
                 Ok(audit) => audit,
                 Err(err) => {
                     if no_layout_error() {
-                        error!(?err);
+                        error!(?err, "skip the error by setting empty audit result");
                         Default::default()
                     } else {
                         return Err(err);

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -586,9 +586,13 @@ fn lib_pkgs(workspaces: &Workspaces) -> IndexMap<XString, PkgFeaturesLib> {
                     is_lib: false,
                 },
             );
-            if no_layout_error() {
+            if no_layout_error() && old.is_some() {
                 // solana-foundation/anchor: Package `crank` already exists.
-                error!("Package `{}` already exists.\nOld={old:?}", p.name);
+                error!(
+                    "Package `{}` already exists.\nOld={:?}",
+                    p.name,
+                    old.unwrap()
+                );
             } else {
                 assert!(
                     old.is_none(),

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -32,8 +32,12 @@ pub use detect_targets::RustToolchain;
 mod audit;
 
 /// 寻找仓库内所有 Cargo.toml 所在的路径
-fn find_all_cargo_toml_paths<E: Exclude>(repo_root: &str, dirs_excluded: E) -> Vec<Utf8PathBuf> {
-    let mut cargo_tomls = walk_dir(repo_root, 10, dirs_excluded, |file_path| {
+fn find_all_cargo_toml_paths<E: Exclude>(
+    repo_root: &str,
+    dirs_excluded: E,
+    only_dirs: &[glob::Pattern],
+) -> Vec<Utf8PathBuf> {
+    let mut cargo_tomls = walk_dir(repo_root, 10, dirs_excluded, only_dirs, |file_path| {
         let file_name = file_path.file_name()?;
         // 只搜索 Cargo.toml 文件
         if file_name == "Cargo.toml" {
@@ -137,10 +141,14 @@ impl fmt::Debug for Layout {
 }
 
 impl Layout {
-    pub fn parse<E: Exclude>(repo_root: &str, dirs_excluded: E) -> Result<Layout> {
+    pub fn parse<E: Exclude>(
+        repo_root: &str,
+        dirs_excluded: E,
+        only_dirs: &[glob::Pattern],
+    ) -> Result<Layout> {
         let root_path = Utf8PathBuf::from(repo_root).canonicalize_utf8()?;
 
-        let cargo_tomls = find_all_cargo_toml_paths(repo_root, dirs_excluded);
+        let cargo_tomls = find_all_cargo_toml_paths(repo_root, dirs_excluded, only_dirs);
         ensure!(
             !cargo_tomls.is_empty(),
             "repo_root `{repo_root}` (规范路径为 `{root_path}`) 不是 Rust \
@@ -187,7 +195,7 @@ impl Layout {
         let parse_error = strip_ansi_escapes::strip_str(err).into_boxed_str();
 
         let root_path = Utf8PathBuf::from(repo_root);
-        let cargo_tomls = find_all_cargo_toml_paths(repo_root, empty());
+        let cargo_tomls = find_all_cargo_toml_paths(repo_root, empty(), &[]);
         let (workspaces, packages_info, installation) = Default::default();
         Layout {
             root_path,

--- a/src/layout/tests.rs
+++ b/src/layout/tests.rs
@@ -9,9 +9,9 @@ use expect_test::{expect, expect_file};
 fn arceos_layout() {
     crate::logger::init();
     let excluded = &["tmp"];
-    assert!(Layout::parse("tmp", excluded).is_err());
+    assert!(Layout::parse("tmp", excluded, &[]).is_err());
 
-    let arceos = Layout::parse("./repos/arceos", excluded).unwrap();
+    let arceos = Layout::parse("./repos/arceos", excluded, &[]).unwrap();
     expect_file!["./snapshots/arceos.txt"].assert_debug_eq(&arceos);
     expect_file!["./snapshots/arceos-packages.txt"].assert_debug_eq(&arceos.packages());
 }
@@ -19,7 +19,7 @@ fn arceos_layout() {
 #[test]
 fn cargo_check_verbose() -> Result<()> {
     crate::logger::init();
-    let layout = Layout::parse("repos/e1000-driver", &[])?;
+    let layout = Layout::parse("repos/e1000-driver", crate::utils::empty(), &[])?;
     expect_file!["./snapshots/e1000-driver.txt"].assert_debug_eq(&layout);
     Ok(())
 }

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -112,8 +112,13 @@ pub struct Repo {
 }
 
 impl Repo {
-    fn new_or_empty<E: Exclude>(repo_root: &str, dirs_excluded: E, config: Config) -> Repo {
-        let layout = Layout::parse(repo_root, dirs_excluded)
+    fn new_or_empty<E: Exclude>(
+        repo_root: &str,
+        dirs_excluded: E,
+        only_dirs: &[glob::Pattern],
+        config: Config,
+    ) -> Repo {
+        let layout = Layout::parse(repo_root, dirs_excluded, only_dirs)
             .with_context(|| eyre!("无法解析 `{repo_root}` 内的 Rust 项目布局"));
         match layout {
             Ok(layout) => Self { layout, config },
@@ -210,7 +215,13 @@ impl TryFrom<Config> for Repo {
     fn try_from(mut config: Config) -> Result<Repo> {
         let repo_root = config.local_root_path_with_git_clone()?;
         let skip_dir = config.skip_pkg_dir_globs();
-        Ok(Repo::new_or_empty(repo_root.as_str(), skip_dir, config))
+        let only_dir = config.only_pkg_dir_globs();
+        Ok(Repo::new_or_empty(
+            repo_root.as_str(),
+            skip_dir,
+            &only_dir,
+            config,
+        ))
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -86,7 +86,7 @@ pub fn walk_dir<T, E: Exclude>(
                 .unwrap_or(entry.path())
                 .to_str()
                 .unwrap();
-            debug!(?dir, ?path, ?only_dirs);
+            trace!(?dir, ?path, ?only_dirs);
             if path.is_empty() {
                 // enter root
                 return true;
@@ -153,4 +153,14 @@ fn test_walk() {
     // file path depends on the given path on relative or absolute aspect
     let files = walk_dir(".", 2, empty(), &[], Some);
     dbg!(files);
+}
+
+#[test]
+fn test_glob() {
+    use exlucded::pat;
+
+    let pat_a = pat("a*");
+    assert!(pat_a.matches("a"));
+    let pat_a_rec = pat("a/**");
+    assert!(pat_a_rec.matches("a/b"));
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -87,6 +87,10 @@ pub fn walk_dir<T, E: Exclude>(
                 .to_str()
                 .unwrap();
             debug!(?dir, ?path, ?only_dirs);
+            if path.is_empty() {
+                // enter root
+                return true;
+            }
             only_dirs.iter().any(|pat| pat.matches(path))
         })
         .filter_map(|entry| {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -86,6 +86,7 @@ pub fn walk_dir<T, E: Exclude>(
                 .unwrap_or(entry.path())
                 .to_str()
                 .unwrap();
+            debug!(?dir, ?path, ?only_dirs);
             only_dirs.iter().any(|pat| pat.matches(path))
         })
         .filter_map(|entry| {


### PR DESCRIPTION
This PR
* removes single and batch features in  os-checker-database
* os-checker run subcommand adds --no-layout-error
* applies --no-layout-error
* input JSON supports meta.only_pkg_dir_globs field
* batch CLI adds --no-upload option