### PR TITLE
Feat:  support `meta.rerun` in config JSON

### DIFF
--- a/os-checker-types/src/config.rs
+++ b/os-checker-types/src/config.rs
@@ -42,6 +42,12 @@ pub enum MaybeMulti {
     Multi(Vec<String>),
 }
 
+impl Default for MaybeMulti {
+    fn default() -> Self {
+        MaybeMulti::Multi(Vec::new())
+    }
+}
+
 impl fmt::Debug for MaybeMulti {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -89,12 +95,16 @@ impl Cmds {
 
 #[derive(Debug, Serialize, Deserialize, Encode, Decode, Clone)]
 pub struct Meta {
+    #[serde(default)]
     pub only_pkg_dir_globs: MaybeMulti,
+    #[serde(default)]
     pub skip_pkg_dir_globs: MaybeMulti,
     /// { "target1": { "ENV1": "val" } }
     #[serde(default)]
     #[musli(with = musli::serde)]
     pub target_env: TargetEnv,
+    #[serde(default)]
+    pub rerun: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -225,6 +225,11 @@ impl RepoConfig {
     pub fn sort_packages(&mut self) {
         self.packages.sort_unstable_keys();
     }
+
+    /// Rerun checks for a repo.
+    pub fn rerun(&self) -> bool {
+        self.meta.as_ref().map(|meta| meta.rerun).unwrap_or(false)
+    }
 }
 
 /// TODO: 其他工具待完成

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -187,9 +187,13 @@ pub struct Meta {
 
     #[serde(default = "defalt_skip_pkg_dir_globs")]
     skip_pkg_dir_globs: MaybeMulti,
+
     /// { "target1": { "ENV1": "val" } }
     #[serde(default)]
     pub target_env: TargetEnv,
+
+    #[serde(default)]
+    pub rerun: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Default)]
@@ -265,6 +269,7 @@ impl Default for Meta {
             only_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
             skip_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
             target_env: TargetEnv::default(),
+            rerun: false,
         }
     }
 }

--- a/src/config/deserialization/config_options/type_conversion.rs
+++ b/src/config/deserialization/config_options/type_conversion.rs
@@ -33,11 +33,13 @@ impl From<Meta> for out::Meta {
             only_pkg_dir_globs,
             skip_pkg_dir_globs,
             target_env,
+            rerun,
         } = value;
         Self {
             only_pkg_dir_globs: only_pkg_dir_globs.into(),
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
             target_env: target_env.into(),
+            rerun,
         }
     }
 }
@@ -88,11 +90,13 @@ impl From<out::Meta> for Meta {
             only_pkg_dir_globs,
             skip_pkg_dir_globs,
             target_env,
+            rerun,
         } = value;
         Self {
             only_pkg_dir_globs: only_pkg_dir_globs.into(),
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
             target_env: target_env.into(),
+            rerun,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -113,6 +113,10 @@ impl Config {
     pub fn skip_pkg_dir_globs(&self) -> Box<[glob::Pattern]> {
         self.config.skip_pkg_dir_globs()
     }
+
+    pub fn rerun(&self) -> bool {
+        self.config.rerun()
+    }
 }
 
 impl TryFrom<Value> for Config {

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -320,6 +320,30 @@ impl std::fmt::Debug for Output {
 }
 
 impl Output {
+    fn new_cargo_from_tool(
+        tool: CheckerTool,
+        err: eyre::Report,
+        now_utc: OffsetDateTime,
+        duration_ms: u64,
+        resolve: Resolve,
+    ) -> Self {
+        Output {
+            raw: RawOutput {
+                status: std::process::ExitStatus::default(),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            },
+            parsed: OutputParsed::Cargo {
+                source: CargoSource::Checker(tool),
+                stderr: format!("{err:?}"),
+            },
+            count: 1,
+            now_utc,
+            duration_ms,
+            resolve,
+        }
+    }
+
     /// NOTE: &self 应该为非 Cargo checker，即来自实际检查工具的输出
     fn new_cargo_from_checker(&self, stderr_parsed: String) -> Self {
         Output {
@@ -397,8 +421,9 @@ fn run_check(
     let stdout: &[_] = &raw.stdout;
     let stderr: &[_] = &raw.stderr;
     let parsed = match resolve.checker {
-        CheckerTool::Fmt => {
-            let fmt = serde_json::from_slice(stdout).with_context(|| {
+        CheckerTool::Fmt => serde_json::from_slice(stdout)
+            .map(OutputParsed::Fmt)
+            .with_context(|| {
                 format!(
                     "无法解析 rustfmt 的标准输出：stdout={}\n原始命令为：\
                     `{}`（即 `{:?}`）\ntoolchain={}\nstderr={}",
@@ -408,68 +433,71 @@ fn run_check(
                     resolve.toolchain(),
                     String::from_utf8_lossy(stderr),
                 )
-            })?;
-            OutputParsed::Fmt(fmt)
-        }
-        CheckerTool::Clippy => OutputParsed::Clippy(
-            CargoMessage::parse_stream(stdout)
-                .map(|mes| {
-                    mes.map(RustcMessage::from).with_context(|| {
-                        format!(
-                            "解析 Clippy Json 输出失败：stdout={}\n原始命令为：\
+            })
+            .map_err(|err| (CheckerTool::Fmt, err)),
+        CheckerTool::Clippy => CargoMessage::parse_stream(stdout)
+            .map(|mes| {
+                mes.map(RustcMessage::from).with_context(|| {
+                    format!(
+                        "解析 Clippy Json 输出失败：stdout={}\n原始命令为：\
                             `{}`（即 `{:?}`）\ntoolchain={}\nstderr={}",
-                            String::from_utf8_lossy(stdout),
-                            resolve.cmd,
-                            resolve.expr,
-                            resolve.toolchain(),
-                            String::from_utf8_lossy(stderr),
-                        )
-                    })
+                        String::from_utf8_lossy(stdout),
+                        resolve.cmd,
+                        resolve.expr,
+                        resolve.toolchain(),
+                        String::from_utf8_lossy(stderr),
+                    )
                 })
-                .collect::<Result<_>>()?,
-        ),
-        CheckerTool::Mirai => OutputParsed::Mirai(
-            CargoMessage::parse_stream(stdout)
-                .map(|mes| {
-                    mes.map(RustcMessage::from).with_context(|| {
-                        format!(
-                            "解析 Mirai Json 输出失败：stdout={}\n原始命令为：\
+            })
+            .collect::<Result<_>>()
+            .map(OutputParsed::Clippy)
+            .map_err(|err| (CheckerTool::Clippy, err)),
+        CheckerTool::Mirai => CargoMessage::parse_stream(stdout)
+            .map(|mes| {
+                mes.map(RustcMessage::from).with_context(|| {
+                    format!(
+                        "解析 Mirai Json 输出失败：stdout={}\n原始命令为：\
                             `{}`（即 `{:?}`）\ntoolchain={}\nstderr={}",
-                            String::from_utf8_lossy(stdout),
-                            resolve.cmd,
-                            resolve.expr,
-                            resolve.toolchain(),
-                            String::from_utf8_lossy(stderr),
-                        )
-                    })
+                        String::from_utf8_lossy(stdout),
+                        resolve.cmd,
+                        resolve.expr,
+                        resolve.toolchain(),
+                        String::from_utf8_lossy(stderr),
+                    )
                 })
-                .collect::<Result<_>>()?,
-        ),
-        CheckerTool::Lockbud => OutputParsed::Lockbud(lockbud::parse_lockbud_result(stderr)),
-        CheckerTool::Rapx => OutputParsed::Rap(rap::rap_output(stderr, stdout, &resolve)),
-        CheckerTool::Rudra => OutputParsed::Rudra(rudra::parse(stderr, &resolve)),
-        CheckerTool::Audit => OutputParsed::Audit(resolve.audit.clone()),
-        CheckerTool::Outdated => OutputParsed::Outdated(outdated::parse_outdated(&raw, &resolve)),
-        CheckerTool::Geiger => OutputParsed::Geiger(geiger::parse(&raw, &resolve)),
+            })
+            .collect::<Result<_>>()
+            .map(OutputParsed::Mirai)
+            .map_err(|err| (CheckerTool::Mirai, err)),
+        CheckerTool::Lockbud => Ok(OutputParsed::Lockbud(lockbud::parse_lockbud_result(stderr))),
+        CheckerTool::Rapx => Ok(OutputParsed::Rap(rap::rap_output(stderr, stdout, &resolve))),
+        CheckerTool::Rudra => Ok(OutputParsed::Rudra(rudra::parse(stderr, &resolve))),
+        CheckerTool::Audit => Ok(OutputParsed::Audit(resolve.audit.clone())),
+        CheckerTool::Outdated => Ok(OutputParsed::Outdated(outdated::parse_outdated(
+            &raw, &resolve,
+        ))),
+        CheckerTool::Geiger => Ok(OutputParsed::Geiger(geiger::parse(&raw, &resolve))),
         CheckerTool::Miri => todo!(),
-        CheckerTool::SemverChecks => {
-            OutputParsed::SemverChecks(semver_checks::parse(&raw, &resolve))
-        }
+        CheckerTool::SemverChecks => Ok(OutputParsed::SemverChecks(semver_checks::parse(
+            &raw, &resolve,
+        ))),
         // 由于 run_check 只输出单个 Ouput，而其他检查工具可能会利用 cargo，因此导致发出两类诊断
         CheckerTool::Cargo => panic!("Don't specify cargo as a checker. It's a virtual one."),
     };
-    let count = parsed.count();
-    let output = Output {
-        raw,
-        parsed,
-        count,
-        now_utc,
-        duration_ms,
-        resolve,
+
+    let output = match parsed {
+        Ok(parsed) => Output {
+            raw,
+            count: parsed.count(),
+            parsed,
+            now_utc,
+            duration_ms,
+            resolve,
+        },
+        Err((tool, err)) => Output::new_cargo_from_tool(tool, err, now_utc, duration_ms, resolve),
     };
 
     outputs.push_output_with_cargo(output, db_repo, now_utc);
-
     Ok(())
 }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -238,7 +238,7 @@ impl RepoOutput {
 
         let info = config.new_info()?;
 
-        if utils::force_repo_check() {
+        if utils::force_repo_check() || config.rerun() {
             warn!("强制运行检查（不影响已有的检查缓存结果）");
         } else if let Some(db) = config.db() {
             match info.get_from_db(db) {


### PR DESCRIPTION
This PR
* add `meta.rerun` in config JSON
  * close https://github.com/os-checker/os-checker/issues/329
  * this breaks cache format
* handle fmt, clippy, and mirai panic errors as Cargo error ouput

