### PR TITLE
Feat: Support local project checking and caching

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,7 @@ pub use resolve::Resolve;
 
 mod merge_from_json;
 mod uri;
+pub use uri::Uri;
 
 mod checker;
 pub use checker::{CheckerTool, TOOLS};
@@ -71,10 +72,9 @@ impl Config {
     }
 
     pub fn new_info(&self) -> Result<Box<InfoKeyValue>> {
-        let user = self.user_name();
-        let repo = self.repo_name();
+        let uri = &self.uri;
         let config = &*self.config;
-        get_info(user, repo, config.clone()).map(Box::new)
+        get_info(uri, config.clone()).map(Box::new)
     }
 
     /// 解析该仓库所有 package 的检查执行命令

--- a/src/db/info/local.rs
+++ b/src/db/info/local.rs
@@ -1,0 +1,79 @@
+//! Get info for local projects.
+use super::{Committer, LatestCommit};
+use crate::Result;
+use duct::cmd;
+use eyre::{Context, ContextCompat};
+use os_checker_types::unix_timestamp_milli;
+use time::format_description::well_known::Rfc2822;
+
+pub fn info_repo(path: &str) -> Result<(String, LatestCommit)> {
+    let branch = current_branch(path)?;
+    let commit = latest_commit(path)?;
+    Ok((branch, commit))
+}
+
+fn current_branch(path: &str) -> Result<String> {
+    let branch = cmd!("git", "branch", "--show-current").dir(path).read()?;
+    Ok(branch.trim().to_owned())
+}
+
+fn latest_commit(path: &str) -> Result<LatestCommit> {
+    // git log -1 --pretty=tformat:"SHA: %H%nAuthor: %an <%ae>%nCommitter: %cn <%ce>%nCommit Header: %s"
+    let output = cmd!(
+        "git",
+        "log",
+        "-1",
+        "--pretty=tformat:SHA: %H%nCommit Header: %s%nAuthor: %an%nAuthor Email: %ae%n\
+            Author Date: %ad%nCommitter: %cn%nCommitter Email: %ce%nCommitter Date: %cd",
+        "--date=rfc"
+    )
+    .dir(path)
+    .read()?;
+
+    // $ git log -1 --pretty=tformat:"SHA: %H%nCommit Header: %s%nAuthor: %an%nAuthor Email: %ae%nAuthor Date: %ad%nCommitter: %cn%nCommitter Email: %ce%nCommitter Date: %cd"
+    // SHA: 4c603baeb747801449a7d20fff4a5be08624c4db
+    // Commit Header: chore: remove verbose logs
+    // Author: zjp
+    // Author Email: jiping_zhou@foxmail.com
+    // Author Date: Tue, 6 May 2025 22:44:25 +0800
+    // Committer: zjp
+    // Committer Email: jiping_zhou@foxmail.com
+    // Committer Date: Tue, 6 May 2025 22:44:25 +0800
+    let lines: Vec<_> = output.trim().lines().collect();
+    ensure!(lines.len() == 8, "lines={lines:?} doesn't have 8 lines");
+    let get = |idx: usize, prefix: &str| {
+        lines[idx]
+            .strip_prefix(prefix)
+            .with_context(|| format!("{:?} doesn't have prefix {prefix:?}", lines[idx]))
+            .map(String::from)
+    };
+    Ok(LatestCommit {
+        sha: get(0, "SHA: ")?,
+        mes: get(1, "Commit Header: ")?,
+        author: Committer {
+            name: get(2, "Author: ")?.into(),
+            email: get(3, "Author Email: ")?,
+            datetime: {
+                let date = get(4, "Author Date: ")?;
+                unix_timestamp_milli(
+                    time::OffsetDateTime::parse(&date, &Rfc2822)
+                        .with_context(|| format!("{date:?} is not parsed"))?,
+                )
+            },
+        },
+        committer: Committer {
+            name: get(5, "Committer: ")?.into(),
+            email: get(6, "Committer Email: ")?,
+            datetime: unix_timestamp_milli(time::OffsetDateTime::parse(
+                &get(7, "Committer Date: ")?,
+                &Rfc2822,
+            )?),
+        },
+    })
+}
+
+#[test]
+fn local_info_repo() {
+    let (branch, commit) = info_repo(".").unwrap();
+    dbg!(branch, commit);
+}

--- a/src/layout/targets/mod.rs
+++ b/src/layout/targets/mod.rs
@@ -193,7 +193,6 @@ impl PackageInfo {
         } = pkg;
         targets.merge_more(&pkg_dir, repo_targets)?;
 
-        debug!(?targets);
         Ok(PackageInfo {
             pkg_name,
             pkg_dir,

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -99,7 +99,6 @@ impl RepoOutput {
     }
 
     /// 提前删除仓库目录
-    #[instrument(level = "trace")]
     pub fn clean_repo_dir(&self) -> Result<()> {
         self.repo.config.clean_repo_dir()
     }

--- a/src/utils/scan_for_targets.rs
+++ b/src/utils/scan_for_targets.rs
@@ -30,11 +30,7 @@ fn pattern_target_list() -> String {
 // e.g. static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?-u:\b)(x86_64-unknown-linux-gnu)(?-u:\b)"));
 static RE: LazyLock<Regex> = LazyLock::new(|| {
     let pattern = pattern_target_list();
-    Regex::new(&pattern)
-        .inspect(|r| {
-            debug!(static_captures_len = r.static_captures_len(), %pattern);
-        })
-        .unwrap()
+    Regex::new(&pattern).unwrap()
 });
 
 fn extract(src: &[u8]) -> impl Iterator<Item = &'_ str> {


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/318

NOTE: the last two parent folder names are `user/repo`,
even though the user may donesn't make sense.
So local projects are better put into a folder name __local
to indicate the name doesn't correspond to a github user.