### PR TITLE
Chore: make resolve logging prettier and with progress numbers

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -290,7 +290,7 @@ fn repos_outputs(
         .into_iter()
         .map(move |mut config| {
             config.set_db(db.clone());
-            RepoOutput::try_new(config)
+            RepoOutput::run(config)
         }))
 }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -11,6 +11,7 @@ use cargo_metadata::{
     diagnostic::DiagnosticLevel,
     Message as CargoMessage,
 };
+use color_eyre::owo_colors::OwoColorize;
 use either::Either;
 use eyre::Context;
 use itertools::Itertools;
@@ -185,13 +186,13 @@ impl Repo {
                     let len_checker_resolves = checker_resolves.len();
                     for (idx_resolve, resolve) in checker_resolves.into_iter().enumerate() {
                         debug!(
-                            len_resolves,
-                            len_finished_resolves,
-                            len_group_by_checker,
-                            idx_checker,
-                            current = ?checker,
-                            len_checker_resolves,
-                            idx_resolve
+                            len_resolves = %(len_resolves.red().bold()),
+                            len_finished_resolves = %(len_finished_resolves.red()),
+                            len_group_by_checker = %(len_group_by_checker.yellow().bold()),
+                            idx_checker = %(idx_checker.yellow()),
+                            current = ?(checker.blue().bold()),
+                            len_checker_resolves = %(len_checker_resolves.blue().bold()),
+                            idx_resolve = %(idx_resolve.blue())
                         );
                         run_check(resolve, &mut outputs, db_repo)?;
                         len_finished_resolves += 1;

--- a/src/run_checker/packages_outputs.rs
+++ b/src/run_checker/packages_outputs.rs
@@ -172,16 +172,16 @@ fn cargo_stderr_stripped(output: &Output, now_utc: OffsetDateTime) -> Option<Str
     let raw_stderr = output.raw.stderr.as_slice();
     let stderr = String::from_utf8_lossy(raw_stderr);
 
-    debug!(%resolve.pkg_name, %resolve.pkg_dir);
     debug!(
+        %resolve.pkg_name, %resolve.pkg_dir,
         success = %(if output.raw.status.success() {
             "true".bright_green().to_string()
         } else {
             "false".bright_red().to_string()
         }),
-        resolve.cmd = %resolve.cmd.bright_black().italic()
+        resolve.cmd = %resolve.cmd.bright_black().italic(),
+        stderr=%(stderr.on_bright_black())
     );
-    debug!("stderr=\n{stderr}\n");
 
     let stderr_stripped = strip_ansi_escapes::strip(raw_stderr);
     let stderr = String::from_utf8_lossy(&stderr_stripped);


### PR DESCRIPTION
close https://github.com/os-checker/os-checker/issues/340

for 1: each resolve has been already logged with a pkg name and dir, so no need to add anything
for 2: the target logging is removed in a previous commit

This PR mainly adds progress report through various numbers

```rust
len_resolves = %(len_resolves.red().bold()),
len_finished_resolves = %(len_finished_resolves.red()),
len_group_by_checker = %(len_group_by_checker.yellow().bold()),
idx_checker = %(idx_checker.yellow()),
current = ?(checker.blue().bold()),
len_checker_resolves = %(len_checker_resolves.blue().bold()),
idx_resolve = %(idx_resolve.blue())
```

![截图_20250507214430](https://github.com/user-attachments/assets/b75e488f-74e4-43e4-9bf6-797560f02ba8)
