### PR TITLE
Feat: add `meta.use_last_cache` in JSON config and `--use-last-cache` in run subcommand

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -95,7 +95,7 @@ jobs:
 
           # make run || echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
           # 仅在支持新检查时采用 batch，因为中途一旦出错，只使用 run 无法在中途上传检查结果的缓存数据
-          batch --size 16 #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
+          batch --size 16 -- --use-last-cache #|| echo "运行所有仓库的检查失败，但依然提交已有的 cache.redb 到数据仓库"
 
           os-checker db --done cache.redb
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -2,7 +2,7 @@ name: Run Checkers
 
 on:
   push:
-    branches: [ main, feat/*, fix/* ]
+    branches:
   schedule:
     - cron: '0 20 * * *'
   workflow_dispatch:

--- a/os-checker-database/examples/lockbud/mod.rs
+++ b/os-checker-database/examples/lockbud/mod.rs
@@ -58,7 +58,7 @@ impl Lockbud {
         match self.bug_kind {
             BugKind::DoubleLock => DeadlockDiagnosis::double_lock(val).1,
             BugKind::ConflictLock => DeadlockDiagnosis::conflict_lock(val).1,
-            BugKind::CondvarDeadlock => CondvarDeadlockDiagnosis::new(val).1,
+            BugKind::CondvarDeadlock | BugBugKind::CondvarDeadlockDesciption => CondvarDeadlockDiagnosis::new(val).1,
             BugKind::AtomicityViolation => AtomicityViolationDiagnosis::new(val).1,
             BugKind::InvalidFree | BugKind::UseAfterFree => {
                 RE.parse_file_paths(val.as_str().unwrap())
@@ -71,7 +71,10 @@ impl Lockbud {
 pub enum BugKind {
     DoubleLock,
     ConflictLock,
+    /// This variant is only for bug_kind field, not map key.
+    /// cc https://github.com/os-checker/os-checker/issues/348
     #[serde(rename = "Deadlock before Condvar::wait and notify")]
+    CondvarDeadlockDesciption,
     CondvarDeadlock,
     AtomicityViolation,
     InvalidFree,

--- a/os-checker-database/examples/lockbud/mod.rs
+++ b/os-checker-database/examples/lockbud/mod.rs
@@ -58,7 +58,9 @@ impl Lockbud {
         match self.bug_kind {
             BugKind::DoubleLock => DeadlockDiagnosis::double_lock(val).1,
             BugKind::ConflictLock => DeadlockDiagnosis::conflict_lock(val).1,
-            BugKind::CondvarDeadlock | BugBugKind::CondvarDeadlockDesciption => CondvarDeadlockDiagnosis::new(val).1,
+            BugKind::CondvarDeadlock | BugKind::CondvarDeadlockDesciption => {
+                CondvarDeadlockDiagnosis::new(val).1
+            }
             BugKind::AtomicityViolation => AtomicityViolationDiagnosis::new(val).1,
             BugKind::InvalidFree | BugKind::UseAfterFree => {
                 RE.parse_file_paths(val.as_str().unwrap())

--- a/os-checker-database/examples/lockbud/mod.rs
+++ b/os-checker-database/examples/lockbud/mod.rs
@@ -71,6 +71,7 @@ impl Lockbud {
 pub enum BugKind {
     DoubleLock,
     ConflictLock,
+    #[serde(rename = "Deadlock before Condvar::wait and notify")]
     CondvarDeadlock,
     AtomicityViolation,
     InvalidFree,

--- a/os-checker-types/src/config.rs
+++ b/os-checker-types/src/config.rs
@@ -105,6 +105,8 @@ pub struct Meta {
     pub target_env: TargetEnv,
     #[serde(default)]
     pub rerun: bool,
+    #[serde(default)]
+    pub use_last_cache: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -168,6 +168,10 @@ pub struct ArgsRun {
     /// redb file path. If not specified, no cache for checking.
     #[argh(option)]
     db: Option<Utf8PathBuf>,
+
+    /// enable meta.use_last_cache for all repos
+    #[argh(switch)]
+    use_last_cache: bool,
 }
 
 /// Merge configs and split it into batches.
@@ -295,9 +299,9 @@ fn repos_outputs(
 }
 
 impl ArgsRun {
-    #[instrument(level = "trace")]
     fn execute(&self) -> Result<()> {
         NO_LAYOUT_ERROR.store(self.no_layout_error, Ordering::SeqCst);
+        USE_LAST_CACHE.store(self.use_last_cache, Ordering::SeqCst);
 
         let db = self.db.as_deref().map(Db::new).transpose()?;
         let start = SystemTime::now();
@@ -461,4 +465,11 @@ static NO_LAYOUT_ERROR: AtomicBool = AtomicBool::new(false);
 
 pub fn no_layout_error() -> bool {
     NO_LAYOUT_ERROR.load(Ordering::SeqCst)
+}
+
+/// Only for layout subcommand.
+static USE_LAST_CACHE: AtomicBool = AtomicBool::new(false);
+
+pub fn use_last_cache() -> bool {
+    USE_LAST_CACHE.load(Ordering::SeqCst)
 }

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -232,9 +232,10 @@ impl RepoConfig {
         self.packages.sort_unstable_keys();
     }
 
-    /// Rerun checks for a repo.
-    pub fn rerun(&self) -> bool {
-        self.meta.as_ref().map(|meta| meta.rerun).unwrap_or(false)
+    /// Get data from meta field.
+    /// Directly returns None value if meta is None.
+    pub fn get_meta<T>(&self, f: impl FnOnce(&Meta) -> T) -> Option<T> {
+        self.meta.as_ref().map(f)
     }
 }
 

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -192,12 +192,16 @@ impl RepoConfig {
         Ok(())
     }
 
-    pub fn validate_skip_pkg_dir_globs(&self, repo: &str) -> Result<()> {
+    pub fn validate_meta(&self, repo: &str) -> Result<()> {
         if let Some(meta) = &self.meta {
             meta.check_skip_pkg_dir_globs()
-                .with_context(|| format!("{repo}'s meta.skip_pkg_dir_globs value is invalid."))?;
+                .with_context(|| format!("{repo:?}'s meta.skip_pkg_dir_globs value is invalid."))?;
             meta.check_only_pkg_dir_globs()
-                .with_context(|| format!("{repo}'s meta.only_pkg_dir_globs value is invalid."))?;
+                .with_context(|| format!("{repo:?}'s meta.only_pkg_dir_globs value is invalid."))?;
+            ensure!(
+                !(meta.rerun && meta.use_last_cache),
+                "meta.rerun and meta.use_last_cache can't be both true in {repo:?}"
+            );
         }
         Ok(())
     }

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -214,6 +214,9 @@ pub struct Meta {
 
     #[serde(default)]
     pub rerun: bool,
+
+    #[serde(default)]
+    pub use_last_cache: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Default)]
@@ -290,6 +293,7 @@ impl Default for Meta {
             skip_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
             target_env: TargetEnv::default(),
             rerun: false,
+            use_last_cache: false,
         }
     }
 }

--- a/src/config/deserialization/config_options/type_conversion.rs
+++ b/src/config/deserialization/config_options/type_conversion.rs
@@ -34,12 +34,14 @@ impl From<Meta> for out::Meta {
             skip_pkg_dir_globs,
             target_env,
             rerun,
+            use_last_cache,
         } = value;
         Self {
             only_pkg_dir_globs: only_pkg_dir_globs.into(),
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
             target_env: target_env.into(),
             rerun,
+            use_last_cache,
         }
     }
 }
@@ -91,12 +93,14 @@ impl From<out::Meta> for Meta {
             skip_pkg_dir_globs,
             target_env,
             rerun,
+            use_last_cache,
         } = value;
         Self {
             only_pkg_dir_globs: only_pkg_dir_globs.into(),
             skip_pkg_dir_globs: skip_pkg_dir_globs.into(),
             target_env: target_env.into(),
             rerun,
+            use_last_cache,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,9 +1,11 @@
 use crate::{
+    cli::use_last_cache,
     db::{get_info, Db, InfoKeyValue},
     layout::Packages,
     Result,
 };
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
+use color_eyre::owo_colors::OwoColorize;
 use eyre::Context;
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -72,10 +74,12 @@ impl Config {
     }
 
     pub fn new_info(&self) -> Result<Box<InfoKeyValue>> {
-        if self.use_last_cache() {
+        if self.use_last_cache() || use_last_cache() {
+            info!("{}", "Try to get last cache.".yellow());
             if let Some(db) = self.db() {
                 let opt = db.get_cached_info_key_and_value(self.user_name(), self.repo_name())?;
                 if let Some(info_key_value) = opt {
+                    info!("{}", "Succeessful to get last cache.".green().bold());
                     // If use_last_cache is set to true, there is db, the cache
                     // exists and succeeds to be fetched, then return Ok.
                     return Ok(Box::new(info_key_value));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -263,7 +263,7 @@ impl TryFrom<Value> for Configs {
                     let config =
                         RepoConfig::deserialize(deserializer).with_context(|| PARSE_JSON_ERROR)?;
                     config.validate_checker_name(&repo)?;
-                    config.validate_skip_pkg_dir_globs(&repo)?;
+                    config.validate_meta(&repo)?;
                     debug!(?config);
                     Ok(Config {
                         uri: uri::uri(repo)?,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -79,7 +79,11 @@ impl Config {
             if let Some(db) = self.db() {
                 let opt = db.get_cached_info_key_and_value(self.user_name(), self.repo_name())?;
                 if let Some(info_key_value) = opt {
-                    info!("{}", "Succeessful to get last cache.".green().bold());
+                    info!(
+                        ?info_key_value,
+                        "{}",
+                        "Succeessful to get last cache.".green().bold()
+                    );
                     // If use_last_cache is set to true, there is db, the cache
                     // exists and succeeds to be fetched, then return Ok.
                     return Ok(Box::new(info_key_value));

--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -37,6 +37,7 @@ impl Db {
     }
 
     pub fn get_info(&self, key: &InfoKey) -> Result<Option<Info>> {
+        debug!(target: "get_info", ?key);
         self.read(INFO, key)
     }
 

--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -1,4 +1,4 @@
-use super::{info::read_cache::CachedAllInfoKeyValue, InfoKeyValue};
+use super::info::read_cache::{CachedAllInfoKeyValue, RcCachedInfoKeyValue};
 use crate::Result;
 use camino::Utf8Path;
 use eyre::Context;
@@ -73,7 +73,7 @@ impl Db {
         &self,
         user: &str,
         repo: &str,
-    ) -> Result<Option<InfoKeyValue>> {
+    ) -> Result<Option<RcCachedInfoKeyValue>> {
         thread_local! {
             static CACHE: RefCell<Option<CachedAllInfoKeyValue>> = Default::default();
         }
@@ -83,7 +83,7 @@ impl Db {
                 *cache = Some(self.get_all_cached_info_key_and_value()?);
             }
             let cache = cache.as_ref().unwrap();
-            Ok(cache.get(user, repo).map(|pair| pair.to_info_key_value()))
+            Ok(cache.get(user, repo))
         })
     }
 

--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -1,4 +1,4 @@
-use super::info::read_cache::CachedAllInfoKeyValue;
+use super::{info::read_cache::CachedAllInfoKeyValue, InfoKeyValue};
 use crate::Result;
 use camino::Utf8Path;
 use eyre::Context;
@@ -6,7 +6,7 @@ use os_checker_types::db::{
     CacheLayout, CacheRepoKey, CacheValue, CheckValue, Info, InfoKey, CHECKS, DATA, INFO, LAYOUT,
 };
 use redb::{Database, Key, ReadableTable, ReadableTableMetadata, Table, TableDefinition, Value};
-use std::sync::Arc;
+use std::{cell::RefCell, sync::Arc};
 
 #[derive(Clone)]
 pub struct Db {
@@ -40,17 +40,50 @@ impl Db {
         self.read(INFO, key)
     }
 
-    /// Get all (InfoKey, Info) in the db.
-    pub fn get_all_cached_info_key_and_value(&self) -> Result<CachedAllInfoKeyValue> {
+    fn get_all_cached_info_key_and_value(&self) -> Result<CachedAllInfoKeyValue> {
         let table = self.db.begin_read()?.open_table(INFO)?;
-        let mut cached = CachedAllInfoKeyValue::with_capacity(table.len()? as usize);
+        let mut cached_info = CachedAllInfoKeyValue::with_capacity(table.len()? as usize);
 
         for item in table.iter()? {
             let (guard_key, guard_val) = item?;
-            cached.push(guard_key.value().into(), guard_val.value().into());
+            let info = guard_val.value();
+            let mut max_ts = None;
+            for cache_key in &info.caches {
+                let Some(cache_value) = self.read(DATA, cache_key)? else {
+                    bail!("{cache_key:?} doesn't points to a CacheValue in {DATA}");
+                };
+                let unix_timestamp_milli = cache_value.unix_timestamp_milli;
+                match max_ts {
+                    // keep old ts if it's already greater
+                    Some(ts) if ts > unix_timestamp_milli => (),
+                    _ => max_ts = Some(unix_timestamp_milli),
+                }
+            }
+            // max_ts is None if no cheching result
+            cached_info.push(guard_key.value().into(), info.into(), max_ts);
         }
+        Ok(cached_info)
+    }
 
-        Ok(cached)
+    /// Get a user/repo's InfoKeyValue in the db.
+    /// The Result::Err indicates a db operation failure, while the Option::None
+    /// indicates a repo can have no cache.
+    pub fn get_cached_info_key_and_value(
+        &self,
+        user: &str,
+        repo: &str,
+    ) -> Result<Option<InfoKeyValue>> {
+        thread_local! {
+            static CACHE: RefCell<Option<CachedAllInfoKeyValue>> = Default::default();
+        }
+        CACHE.with(|cache| {
+            let cache = &mut *cache.borrow_mut();
+            if cache.is_none() {
+                *cache = Some(self.get_all_cached_info_key_and_value()?);
+            }
+            let cache = cache.as_ref().unwrap();
+            Ok(cache.get(user, repo).map(|pair| pair.to_info_key_value()))
+        })
     }
 
     pub fn get_cache(&self, key: &CacheRepoKey) -> Result<Option<CacheValue>> {

--- a/src/db/info/mod.rs
+++ b/src/db/info/mod.rs
@@ -173,6 +173,7 @@ pub fn get_info(uri: &Uri, config: RepoConfig) -> Result<InfoKeyValue> {
     })
 }
 
+#[derive(Debug)]
 pub struct InfoKeyValue {
     key: InfoKey,
     /// 目前所有检查是单线程的，并且每个仓库是独立检查的

--- a/src/db/info/read_cache.rs
+++ b/src/db/info/read_cache.rs
@@ -1,7 +1,7 @@
-use super::{Info, InfoKey};
+use super::{Info, InfoKey, InfoKeyValue};
 use indexmap::IndexMap;
-use os_checker_types::out_json::UserRepo;
-use std::rc::Rc;
+use os_checker_types::{out_json::UserRepo, parse_unix_timestamp_milli};
+use std::{cell::RefCell, fmt, rc::Rc};
 
 /// Extract all info from db and compute necessary data
 /// to identify the last cache for each repo.
@@ -23,13 +23,17 @@ impl CachedAllInfoKeyValue {
         }
     }
 
-    pub fn push(&mut self, key: InfoKey, val: Info) {
+    pub fn push(&mut self, key: InfoKey, val: Info, max_cache_value_timestamp: Option<u64>) {
         let user_repo = key.user_repo();
-        let rc = RcCachedInfoKeyValue::new(key, val);
+        let rc = RcCachedInfoKeyValue::new(key, val, max_cache_value_timestamp);
 
         if let Some(old) = self.latest_commit.get(&user_repo) {
-            if old.committer_datetime() < rc.committer_datetime() {
-                // the added cache is from a newer commit, so replace the old
+            // When comparing Some and None, Some > None, which is good for our case.
+            // This means if an old non-empty result is chosen over a newer empty result.
+            if old.committer_datetime() < rc.committer_datetime()
+                && old.max_cache_value_timestamp < rc.max_cache_value_timestamp
+            {
+                // the added cache is from a newer commit and newer checks, so replace the old
                 self.latest_commit.insert(user_repo, rc.clone());
             }
         } else {
@@ -38,23 +42,57 @@ impl CachedAllInfoKeyValue {
         }
         self.all.push(rc);
     }
+
+    pub fn get(&self, user: &str, repo: &str) -> Option<&InfoKeyValuePair> {
+        let key = UserRepo {
+            user: user.into(),
+            repo: repo.into(),
+        };
+        self.latest_commit.get(&key).map(|pair| &*pair.inner)
+    }
 }
 
 #[derive(Debug)]
-struct InfoKeyValuePair {
-    key: InfoKey,
-    val: Info,
+pub struct InfoKeyValuePair {
+    pub key: InfoKey,
+    pub val: Info,
 }
 
-#[derive(Clone, Debug)]
+impl InfoKeyValuePair {
+    pub fn to_info_key_value(&self) -> InfoKeyValue {
+        InfoKeyValue {
+            key: self.key.clone(),
+            val: RefCell::new(self.val.clone()),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct RcCachedInfoKeyValue {
     inner: Rc<InfoKeyValuePair>,
+    /// The max unix_timestamp_milli among CacheValues through info.caches
+    max_cache_value_timestamp: Option<u64>,
+}
+
+impl fmt::Debug for RcCachedInfoKeyValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RcCachedInfoKeyValue")
+            .field("inner", &self.inner)
+            .field(
+                "max_cache_value_timestamp",
+                &self
+                    .max_cache_value_timestamp
+                    .map(parse_unix_timestamp_milli),
+            )
+            .finish()
+    }
 }
 
 impl RcCachedInfoKeyValue {
-    fn new(key: InfoKey, val: Info) -> Self {
+    fn new(key: InfoKey, val: Info, max_cache_value_timestamp: Option<u64>) -> Self {
         Self {
             inner: Rc::new(InfoKeyValuePair { key, val }),
+            max_cache_value_timestamp,
         }
     }
 
@@ -64,7 +102,7 @@ impl RcCachedInfoKeyValue {
 }
 
 #[test]
-fn size() {
+fn get_all_cached_info_key_and_value() {
     use std::mem::size_of;
     dbg!(
         size_of::<InfoKeyValuePair>(),
@@ -73,6 +111,6 @@ fn size() {
     );
 
     let db = crate::db::Db::new("tmp/cache.redb".into()).unwrap();
-    let cached = db.get_all_cached_info_key_and_value().unwrap();
-    dbg!(cached);
+    // let cached = db.get_all_cached_info_key_and_value().unwrap();
+    // dbg!(cached);
 }

--- a/src/db/info/read_cache.rs
+++ b/src/db/info/read_cache.rs
@@ -43,12 +43,12 @@ impl CachedAllInfoKeyValue {
         self.all.push(rc);
     }
 
-    pub fn get(&self, user: &str, repo: &str) -> Option<&InfoKeyValuePair> {
+    pub fn get(&self, user: &str, repo: &str) -> Option<RcCachedInfoKeyValue> {
         let key = UserRepo {
             user: user.into(),
             repo: repo.into(),
         };
-        self.latest_commit.get(&key).map(|pair| &*pair.inner)
+        self.latest_commit.get(&key).cloned()
     }
 }
 
@@ -98,6 +98,14 @@ impl RcCachedInfoKeyValue {
 
     fn committer_datetime(&self) -> u64 {
         self.inner.val.latest_commit.committer.datetime
+    }
+
+    pub fn info_value(&self) -> &Info {
+        &self.inner.val
+    }
+
+    pub fn to_info_key_value(&self) -> Box<InfoKeyValue> {
+        Box::new(self.inner.to_info_key_value())
     }
 }
 

--- a/src/db/info/read_cache.rs
+++ b/src/db/info/read_cache.rs
@@ -1,0 +1,78 @@
+use super::{Info, InfoKey};
+use indexmap::IndexMap;
+use os_checker_types::out_json::UserRepo;
+use std::rc::Rc;
+
+/// Extract all info from db and compute necessary data
+/// to identify the last cache for each repo.
+#[derive(Debug, Default)]
+pub struct CachedAllInfoKeyValue {
+    /// All (InfoKey, Info) from local db.
+    /// NOTE: this field is initialized only once and never updated
+    /// in single os-checker run.
+    all: Vec<RcCachedInfoKeyValue>,
+    /// Extract the last cache for each user/repo.
+    latest_commit: IndexMap<UserRepo, RcCachedInfoKeyValue>,
+}
+
+impl CachedAllInfoKeyValue {
+    pub fn with_capacity(len: usize) -> Self {
+        Self {
+            all: Vec::with_capacity(len),
+            latest_commit: Default::default(),
+        }
+    }
+
+    pub fn push(&mut self, key: InfoKey, val: Info) {
+        let user_repo = key.user_repo();
+        let rc = RcCachedInfoKeyValue::new(key, val);
+
+        if let Some(old) = self.latest_commit.get(&user_repo) {
+            if old.committer_datetime() < rc.committer_datetime() {
+                // the added cache is from a newer commit, so replace the old
+                self.latest_commit.insert(user_repo, rc.clone());
+            }
+        } else {
+            // the first time to add a cache for this user_repo
+            self.latest_commit.insert(user_repo, rc.clone());
+        }
+        self.all.push(rc);
+    }
+}
+
+#[derive(Debug)]
+struct InfoKeyValuePair {
+    key: InfoKey,
+    val: Info,
+}
+
+#[derive(Clone, Debug)]
+pub struct RcCachedInfoKeyValue {
+    inner: Rc<InfoKeyValuePair>,
+}
+
+impl RcCachedInfoKeyValue {
+    fn new(key: InfoKey, val: Info) -> Self {
+        Self {
+            inner: Rc::new(InfoKeyValuePair { key, val }),
+        }
+    }
+
+    fn committer_datetime(&self) -> u64 {
+        self.inner.val.latest_commit.committer.datetime
+    }
+}
+
+#[test]
+fn size() {
+    use std::mem::size_of;
+    dbg!(
+        size_of::<InfoKeyValuePair>(),
+        size_of::<InfoKey>(),
+        size_of::<Info>(),
+    );
+
+    let db = crate::db::Db::new("tmp/cache.redb".into()).unwrap();
+    let cached = db.get_all_cached_info_key_and_value().unwrap();
+    dbg!(cached);
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,7 +7,7 @@ pub use db::Db;
 
 /// Github APIs
 mod info;
-pub use info::{get_info, InfoKeyValue};
+pub use info::{get_info, read_cache::RcCachedInfoKeyValue, InfoKeyValue};
 
 pub use os_checker_types::db as out;
 pub use os_checker_types::{parse_unix_timestamp_milli, unix_timestamp_milli};


### PR DESCRIPTION
This PR
* adds `meta.use_last_cache` in JSON config
  * closes https://github.com/os-checker/os-checker/issues/344
  * if a cache is found in db, use that info without doing the query again
* adds `--use-last-cache` that will override the settings by enabling `meta.use_last_cache` for all repos in config
* adjusts batch command to support forward os-checker run arguments verbatim via `-- arg1 arg2 ...`
* fixes lockbud's CondvarDeadlockDesciption bugkind in convert_repo_json
  * closes https://github.com/os-checker/os-checker/issues/348