### PR TITLE
Fix: `meta.only_pkg_dir_globs` filters in Cargo.toml paths; `Layout::packages` respects cargo_tomls 

### DIFF
--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -37,7 +37,6 @@ impl Db {
     }
 
     pub fn get_info(&self, key: &InfoKey) -> Result<Option<Info>> {
-        debug!(target: "get_info", ?key);
         self.read(INFO, key)
     }
 

--- a/src/db/info/read_cache.rs
+++ b/src/db/info/read_cache.rs
@@ -108,17 +108,3 @@ impl RcCachedInfoKeyValue {
         Box::new(self.inner.to_info_key_value())
     }
 }
-
-#[test]
-fn get_all_cached_info_key_and_value() {
-    use std::mem::size_of;
-    dbg!(
-        size_of::<InfoKeyValuePair>(),
-        size_of::<InfoKey>(),
-        size_of::<Info>(),
-    );
-
-    let db = crate::db::Db::new("tmp/cache.redb".into()).unwrap();
-    // let cached = db.get_all_cached_info_key_and_value().unwrap();
-    // dbg!(cached);
-}

--- a/src/layout/audit.rs
+++ b/src/layout/audit.rs
@@ -92,12 +92,10 @@ impl CargoAudit {
     }
 
     /// returns the map where the key is pkg name and the value is audit result
-    pub fn new_for_pkgs<'a>(
-        dirs: impl Iterator<Item = &'a Utf8PathBuf>,
-    ) -> Result<IndexMap<XString, Rc<Self>>> {
+    pub fn new_for_pkgs<'a>(dirs: Vec<Utf8PathBuf>) -> Result<IndexMap<XString, Rc<Self>>> {
         let mut map = IndexMap::new();
         for dir in dirs {
-            let audit = Self::new(dir)?;
+            let audit = Self::new(&dir)?;
             for pkg in &audit.problematic_pkgs {
                 // NOTE: there is supposed to be no pkg name aliasing.
                 map.insert(pkg.clone(), audit.clone());

--- a/src/layout/audit.rs
+++ b/src/layout/audit.rs
@@ -92,7 +92,7 @@ impl CargoAudit {
     }
 
     /// returns the map where the key is pkg name and the value is audit result
-    pub fn new_for_pkgs<'a>(dirs: Vec<Utf8PathBuf>) -> Result<IndexMap<XString, Rc<Self>>> {
+    pub fn new_for_pkgs(dirs: Vec<Utf8PathBuf>) -> Result<IndexMap<XString, Rc<Self>>> {
         let mut map = IndexMap::new();
         for dir in dirs {
             let audit = Self::new(&dir)?;

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -143,7 +143,6 @@ pub fn scripts_and_github_dir_in_repo(repo_root: &Utf8Path) -> Result<Targets> {
 
     let github_dir = Utf8Path::new(repo_root).join(".github");
     let github_files = walk_dir(&github_dir, 4, empty(), &[], Some);
-    debug!(%repo_root, ?github_files);
 
     scan_scripts_for_target(&github_files, |target, path| {
         targets.detected_by_repo_github(target, path);

--- a/src/layout/detect_targets.rs
+++ b/src/layout/detect_targets.rs
@@ -168,7 +168,6 @@ fn scripts_in_dir(dir: &Utf8Path, f: impl FnMut(&str, Utf8PathBuf)) -> Result<()
         }
         None
     });
-    debug!(%dir, ?scripts);
     scan_scripts_for_target(&scripts, f)
 }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -280,6 +280,7 @@ impl Layout {
             })
             .collect();
 
+        debug!(pkgs = ?map.keys().collect::<Vec<_>>());
         let repo_root = self.repo_root().to_owned();
         Ok(Packages { repo_root, map })
     }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -14,7 +14,6 @@ use cargo_metadata::{
     camino::{Utf8Path, Utf8PathBuf},
     Metadata, MetadataCommand,
 };
-use eyre::ContextCompat;
 use indexmap::IndexMap;
 use std::{fmt, rc::Rc};
 
@@ -223,10 +222,32 @@ impl Layout {
         // 从根本上解决这个问题，必须不允许同名 package，比如统一成
         // 路径，或者对同名 package 进行检查，必须包含额外的路径。
         // 无论如何，这都带来复杂性，目前来看并不值得。
+        //
+        // NOTE: 这里对 package 进行了筛选，因为 cargo_tomls 结合了配置文件
+        // 中的筛选方式，而不再指向全部 package 的 Cargo.toml.
 
-        let mut libs = lib_pkgs(&self.workspaces);
+        let libs = lib_pkgs(&self.workspaces, &self.cargo_tomls);
         let audit = {
-            let res = CargoAudit::new_for_pkgs(self.workspaces.keys());
+            // query cargo audit with less pkgs
+            let pkg_dirs: Vec<_> = if self.workspaces.len() > self.cargo_tomls.len() {
+                self.cargo_tomls
+                    .iter()
+                    .map(|path| {
+                        let mut path = path.to_owned();
+                        // remove trailling Cargo.toml
+                        assert_eq!(
+                            path.file_name(),
+                            Some("Cargo.toml"),
+                            "{path} must be a Cargo.toml path"
+                        );
+                        path.pop();
+                        path
+                    })
+                    .collect()
+            } else {
+                self.workspaces.keys().cloned().collect()
+            };
+            let res = CargoAudit::new_for_pkgs(pkg_dirs);
             match res {
                 Ok(audit) => audit,
                 Err(err) => {
@@ -243,41 +264,22 @@ impl Layout {
         let map: IndexMap<_, _> = self
             .packages_info
             .iter()
-            .map(|info| {
-                let features_islib = libs
-                    .swap_remove(&info.pkg_name)
-                    .with_context(|| {
-                        // it's almost unlikely to reach here if duplicated package
-                        // name exist, because inserting the second package to libs
-                        // will causes assert! panic.
-                        format!(
-                            "The vec features of package `{}` has been taken out.\n
-                             Maybe there is a duplicated lib crate name?",
-                            info.pkg_name
-                        )
-                    })
-                    .unwrap();
-                (
+            .filter_map(|info| {
+                let features_islib = libs.get(&info.pkg_name)?;
+                Some((
                     info.pkg_name.clone(),
                     PackageInfoShared {
                         pkg_dir: info.pkg_dir.clone(),
                         targets: info.targets.keys().cloned().collect(),
-                        features: features_islib.features,
+                        features: features_islib.features.clone(),
                         toolchain: info.toolchain,
                         audit: audit.get(&info.pkg_name).cloned(),
                         is_lib: features_islib.is_lib,
                     },
-                )
+                ))
             })
             .collect();
-        if map.len() != self.packages_info.len() {
-            let mut count = IndexMap::with_capacity(map.len());
-            for name in self.packages_info.iter().map(|info| &*info.pkg_name) {
-                count.entry(name).and_modify(|c| *c += 1).or_insert(1);
-            }
-            let duplicates: Vec<_> = count.iter().filter(|(_, c)| **c != 1).collect();
-            bail!("暂不支持一个代码仓库中出现同名 packages：{duplicates:?}");
-        }
+
         let repo_root = self.repo_root().to_owned();
         Ok(Packages { repo_root, map })
     }
@@ -574,10 +576,21 @@ struct PkgFeaturesLib {
     is_lib: bool,
 }
 
-fn lib_pkgs(workspaces: &Workspaces) -> IndexMap<XString, PkgFeaturesLib> {
+/// Only extract pkgs from the given cargo_tomls.
+/// By default, cargo_tomls points to the same pkg in Workspaces.
+/// But if filtering, like only_pkg_dir_globs or skip_pkg_dir_globs, is set,
+/// we only want the specifed ones.
+fn lib_pkgs(
+    workspaces: &Workspaces,
+    cargo_tomls: &[Utf8PathBuf],
+) -> IndexMap<XString, PkgFeaturesLib> {
     let mut map = IndexMap::new();
     for ws in workspaces.values() {
         'p: for p in ws.workspace_packages() {
+            if !cargo_tomls.contains(&p.manifest_path) {
+                // skip if the package Cargo.toml is not specifed
+                continue;
+            }
             let features: Vec<String> = p.features.keys().cloned().collect();
             let old = map.insert(
                 XString::new(&*p.name),

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -227,6 +227,7 @@ impl Layout {
         // 中的筛选方式，而不再指向全部 package 的 Cargo.toml.
 
         let libs = lib_pkgs(&self.workspaces, &self.cargo_tomls);
+        info!(?libs);
         let audit = {
             // query cargo audit with less pkgs
             let pkg_dirs: Vec<_> = if self.workspaces.len() > self.cargo_tomls.len() {

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -234,7 +234,6 @@ impl Layout {
         // 中的筛选方式，而不再指向全部 package 的 Cargo.toml.
 
         let libs = lib_pkgs(&self.workspaces, &self.cargo_tomls);
-        info!(?libs);
         let audit = {
             // query cargo audit with less pkgs
             let pkg_dirs: Vec<_> = if self.workspaces.len() > self.cargo_tomls.len() {

--- a/src/layout/targets/mod.rs
+++ b/src/layout/targets/mod.rs
@@ -36,7 +36,13 @@ pub struct Targets {
 
 impl fmt::Debug for Targets {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list().entries(self.keys()).finish()
+        // Only display single string if only one target,
+        // otherwise display a list of targets.
+        if self.len() == 1 {
+            f.write_str(self.get_index(0).unwrap().0)
+        } else {
+            f.debug_list().entries(self.keys()).finish()
+        }
     }
 }
 

--- a/src/layout/targets/mod.rs
+++ b/src/layout/targets/mod.rs
@@ -3,6 +3,7 @@ use crate::{utils::PECULIAR_TARGETS, Result, XString};
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 mod type_conversion;
 
@@ -28,9 +29,15 @@ pub enum TargetSource {
 
 /// A list of target triples obtained from multiple sources.
 /// The orders in key and value demonstrates how they shape.
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[derive(Default, Serialize, Deserialize, Clone)]
 pub struct Targets {
     map: IndexMap<String, Vec<TargetSource>>,
+}
+
+impl fmt::Debug for Targets {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.keys()).finish()
+    }
 }
 
 impl std::ops::Deref for Targets {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -53,6 +53,9 @@ pub fn git_clone(dir: &Utf8Path, url: &str) -> Result<(std::process::Output, u64
 /// 遍历一个目录及其子目录的所有文件（但不进入 .git 和 target 目录）：
 /// * 需要设置一个最大递归深度（虽然可以不设置这个条件，但大部分情况下，os-checker 不需要深度递归）
 /// * op_on_file 为一个回调函数，其参数保证为一个文件路径，且返回值为 Some 时表示把它的值推到 Vec
+///
+/// NOTE: all the given paths and output paths are relative to repo root.
+/// Be carefult when using it by comparing with absolute paths.
 pub fn walk_dir<T, E: Exclude>(
     dir: impl AsRef<Path>,
     max_depth: usize,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -192,15 +192,21 @@ fn test_pat() {
     use exlucded::pat;
 
     let pat1 = pat("crates/a/b*");
-
     assert!(!pat1.matches("crates/a"));
     assert!(pat1.matches("crates/a/b"));
     assert!(pat1.matches("crates/a/bc"));
     assert!(pat1.matches("crates/a/b/c"));
-    let pat2 = pat("*test*");
-    assert!(pat2.matches("test"));
-    assert!(pat2.matches("tests"));
-    assert!(pat2.matches("a-tests"));
-    assert!(pat2.matches("a/tests"));
-    assert!(pat2.matches("a/test/b"));
+
+    let pat2 = pat("crates/a/*");
+    assert!(!pat2.matches("crates/a"));
+    assert!(pat2.matches("crates/a/"));
+    assert!(pat2.matches("crates/a/b"));
+    assert!(pat2.matches("crates/a/b/c"));
+
+    let pat3 = pat("*test*");
+    assert!(pat3.matches("test"));
+    assert!(pat3.matches("tests"));
+    assert!(pat3.matches("a-tests"));
+    assert!(pat3.matches("a/tests"));
+    assert!(pat3.matches("a/test/b"));
 }


### PR DESCRIPTION
This PR
* `meta.only_pkg_dir_globs` takes a relative path pattern to filter in package Cargo.tomls, instead of filtering in folders
  * close https://github.com/os-checker/os-checker/issues/337
*  repects cargo_tomls in `Layout::packages`
* closes https://github.com/os-checker/os-checker/issues/352