### PR TITLE
Feat: support `meta.run_all_checkers` in JSON config

### DIFF
--- a/os-checker-types/src/config.rs
+++ b/os-checker-types/src/config.rs
@@ -95,9 +95,9 @@ impl Cmds {
 
 #[derive(Debug, Serialize, Deserialize, Encode, Decode, Clone)]
 pub struct Meta {
-    #[serde(default)]
+    #[serde(default = "empty_globs")]
     pub only_pkg_dir_globs: MaybeMulti,
-    #[serde(default)]
+    #[serde(default = "empty_globs")]
     pub skip_pkg_dir_globs: MaybeMulti,
     /// { "target1": { "ENV1": "val" } }
     #[serde(default)]
@@ -109,6 +109,9 @@ pub struct Meta {
     pub use_last_cache: bool,
 }
 
+fn empty_globs() -> MaybeMulti {
+    MaybeMulti::Multi(vec![])
+}
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(transparent)]
 pub struct TargetEnv {

--- a/os-checker-types/src/config.rs
+++ b/os-checker-types/src/config.rs
@@ -107,11 +107,18 @@ pub struct Meta {
     pub rerun: bool,
     #[serde(default)]
     pub use_last_cache: bool,
+    #[serde(default = "run_all_checkers")]
+    pub run_all_checkers: bool,
 }
 
 fn empty_globs() -> MaybeMulti {
     MaybeMulti::Multi(vec![])
 }
+
+fn run_all_checkers() -> bool {
+    true
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(transparent)]
 pub struct TargetEnv {

--- a/src/config/deserialization.rs
+++ b/src/config/deserialization.rs
@@ -62,7 +62,12 @@ impl RepoConfig {
 
         let selected_pkgs = self.selected_pkgs(packages)?;
 
-        let mut cmds = Cmds::new_with_all_checkers_enabled();
+        let run_all_checkers = self
+            .meta
+            .as_ref()
+            .map(|meta| meta.run_all_checkers)
+            .unwrap_or_else(config_options::run_all_checkers);
+        let mut cmds = Cmds::new_with_all_checkers_enabled(run_all_checkers);
 
         // validate checkers in cmds
         self.validate_checker(repo, &cmds)?;
@@ -103,7 +108,7 @@ impl RepoConfig {
             resolve_for_single_pkg(&cmds, &pkgs, &mut v)?;
 
             // default to enable all checkers for next package
-            cmds.enable_all_checkers();
+            cmds.enable_all_checkers(run_all_checkers);
         }
 
         v.sort_unstable_by(|a, b| (&a.pkg_name, a.checker).cmp(&(&b.pkg_name, b.checker)));

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -205,6 +205,9 @@ pub struct Meta {
 
     #[serde(default)]
     pub use_last_cache: bool,
+
+    #[serde(default = "run_all_checkers")]
+    run_all_checkers: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Default)]
@@ -274,6 +277,10 @@ fn empty_globs() -> MaybeMulti {
     MaybeMulti::Multi(vec![])
 }
 
+fn run_all_checkers() -> bool {
+    true
+}
+
 impl Default for Meta {
     fn default() -> Self {
         Self {
@@ -282,6 +289,7 @@ impl Default for Meta {
             target_env: TargetEnv::default(),
             rerun: false,
             use_last_cache: false,
+            run_all_checkers: run_all_checkers(),
         }
     }
 }

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -190,10 +190,10 @@ impl std::ops::DerefMut for Cmds {
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct Meta {
-    #[serde(default = "defalt_skip_pkg_dir_globs")]
+    #[serde(default = "empty_globs")]
     only_pkg_dir_globs: MaybeMulti,
 
-    #[serde(default = "defalt_skip_pkg_dir_globs")]
+    #[serde(default = "empty_globs")]
     skip_pkg_dir_globs: MaybeMulti,
 
     /// { "target1": { "ENV1": "val" } }
@@ -270,15 +270,15 @@ fn glob_pattern(s: &str) -> Result<glob::Pattern> {
     glob::Pattern::new(s).with_context(|| format!("{s} is not a valid glob pattern."))
 }
 
-fn defalt_skip_pkg_dir_globs() -> MaybeMulti {
+fn empty_globs() -> MaybeMulti {
     MaybeMulti::Multi(vec![])
 }
 
 impl Default for Meta {
     fn default() -> Self {
         Self {
-            only_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
-            skip_pkg_dir_globs: defalt_skip_pkg_dir_globs(),
+            only_pkg_dir_globs: empty_globs(),
+            skip_pkg_dir_globs: empty_globs(),
             target_env: TargetEnv::default(),
             rerun: false,
             use_last_cache: false,

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -135,44 +135,32 @@ impl JsonSchema for Cmds {
 }
 
 const ENABLED: EnableOrCustom = EnableOrCustom::Enable(true);
+fn default_enabled_checkers() -> IndexMap<CheckerTool, EnableOrCustom> {
+    indexmap::indexmap! {
+        Fmt => ENABLED,
+        Clippy => ENABLED,
+        SemverChecks => ENABLED,
+        Lockbud => ENABLED,
+        Mirai => ENABLED,
+        Audit => ENABLED,
+        Rapx => ENABLED,
+        Rudra => ENABLED,
+        Outdated => ENABLED,
+        Geiger => ENABLED,
+    }
+}
 
 impl Cmds {
     /// TODO: 其他工具待完成
     pub fn new_with_all_checkers_enabled() -> Self {
         Self {
-            map: indexmap::indexmap! {
-                Fmt => ENABLED,
-                Clippy => ENABLED,
-                SemverChecks => ENABLED,
-                Lockbud => ENABLED,
-                Mirai => ENABLED,
-                Audit => ENABLED,
-                Rapx => ENABLED,
-                Rudra => ENABLED,
-                Outdated => ENABLED,
-                Geiger => ENABLED,
-            },
+            map: default_enabled_checkers(),
         }
     }
 
     /// TODO: 其他工具待完成
     pub fn enable_all_checkers(&mut self) {
-        for checker in [
-            Fmt,
-            Clippy,
-            SemverChecks,
-            Lockbud,
-            Mirai,
-            Audit,
-            Rapx,
-            Rudra,
-            Outdated,
-            Geiger,
-        ] {
-            self.entry(checker)
-                .and_modify(|cmd| *cmd = ENABLED)
-                .or_insert(ENABLED);
-        }
+        self.map = default_enabled_checkers();
     }
 
     /// Override self by setting values from the other,

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -135,32 +135,36 @@ impl JsonSchema for Cmds {
 }
 
 const ENABLED: EnableOrCustom = EnableOrCustom::Enable(true);
-fn default_enabled_checkers() -> IndexMap<CheckerTool, EnableOrCustom> {
+const DISABLE: EnableOrCustom = EnableOrCustom::Enable(false);
+
+// The map must contain checker key to validate the JSON config.
+fn default_checkers(run_all_checkers: bool) -> IndexMap<CheckerTool, EnableOrCustom> {
+    let state = || if run_all_checkers { ENABLED } else { DISABLE };
     indexmap::indexmap! {
-        Fmt => ENABLED,
-        Clippy => ENABLED,
-        SemverChecks => ENABLED,
-        Lockbud => ENABLED,
-        Mirai => ENABLED,
-        Audit => ENABLED,
-        Rapx => ENABLED,
-        Rudra => ENABLED,
-        Outdated => ENABLED,
-        Geiger => ENABLED,
+        Fmt => state(),
+        Clippy => state(),
+        SemverChecks => state(),
+        Lockbud => state(),
+        Mirai => state(),
+        Audit => state(),
+        Rapx => state(),
+        Rudra => state(),
+        Outdated => state(),
+        Geiger => state(),
     }
 }
 
 impl Cmds {
     /// TODO: 其他工具待完成
-    pub fn new_with_all_checkers_enabled() -> Self {
+    pub fn new_with_all_checkers_enabled(run_all_checkers: bool) -> Self {
         Self {
-            map: default_enabled_checkers(),
+            map: default_checkers(run_all_checkers),
         }
     }
 
     /// TODO: 其他工具待完成
-    pub fn enable_all_checkers(&mut self) {
-        self.map = default_enabled_checkers();
+    pub fn enable_all_checkers(&mut self, run_all_checkers: bool) {
+        self.map = default_checkers(run_all_checkers);
     }
 
     /// Override self by setting values from the other,
@@ -207,7 +211,7 @@ pub struct Meta {
     pub use_last_cache: bool,
 
     #[serde(default = "run_all_checkers")]
-    run_all_checkers: bool,
+    pub run_all_checkers: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Default)]
@@ -277,7 +281,7 @@ fn empty_globs() -> MaybeMulti {
     MaybeMulti::Multi(vec![])
 }
 
-fn run_all_checkers() -> bool {
+pub fn run_all_checkers() -> bool {
     true
 }
 

--- a/src/config/deserialization/config_options/type_conversion.rs
+++ b/src/config/deserialization/config_options/type_conversion.rs
@@ -35,6 +35,7 @@ impl From<Meta> for out::Meta {
             target_env,
             rerun,
             use_last_cache,
+            run_all_checkers,
         } = value;
         Self {
             only_pkg_dir_globs: only_pkg_dir_globs.into(),
@@ -42,6 +43,7 @@ impl From<Meta> for out::Meta {
             target_env: target_env.into(),
             rerun,
             use_last_cache,
+            run_all_checkers,
         }
     }
 }
@@ -94,6 +96,7 @@ impl From<out::Meta> for Meta {
             target_env,
             rerun,
             use_last_cache,
+            run_all_checkers,
         } = value;
         Self {
             only_pkg_dir_globs: only_pkg_dir_globs.into(),
@@ -101,6 +104,7 @@ impl From<out::Meta> for Meta {
             target_env: target_env.into(),
             rerun,
             use_last_cache,
+            run_all_checkers,
         }
     }
 }


### PR DESCRIPTION
This PR 
* closes https://github.com/os-checker/os-checker/issues/345
  * adds `meta.run_all_checkers` in JSON config, useful when setting it to false to disable all checkers
  * `run --run-checkers` is not implemented for simplicity
  * the new field should work with `cmds.checker`, especially as the following setting shows

```json
{
  "user/repo": {
    "meta": {
      "run_all_checkers": false
    },
    "cmds": {
      "checker1": true
    }
  }
}
```