### PR TITLE
Fix: auto install targets on toolchain required by AtomVChecker; adjusts `FORCE_RUN_CHECK` to accept a set of checkers

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -27,7 +27,7 @@ env:
   # force downloading repos to run check 
   FORCE_REPO_CHECK: false
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: false
+  FORCE_RUN_CHECK: atomvchecker
   # use which configs
   OS_CHECKER_CONFIGS: repos.json # for debug single repo
   # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,12 +25,12 @@ env:
   # checkers in database release
   TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.0.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: true
+  FORCE_RUN_CHECK: false
   # use which configs
-  OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -29,8 +29,8 @@ env:
   # force running checks after downloading repos
   FORCE_RUN_CHECK: false
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,12 +25,12 @@ env:
   # checkers in database release
   TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.0.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: atomvchecker
+  FORCE_RUN_CHECK: false
   # use which configs
-  OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -25,7 +25,7 @@ env:
   # checkers in database release
   TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.0.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # force running checks after downloading repos
   FORCE_RUN_CHECK: atomvchecker
   # use which configs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ os-checker 目前设计为检查 Github 上的仓库代码，并且采用 Github
 
 已集成 [以下检查工具](https://os-checker.github.io/book/checkers.html)：
 
-[![checkers](https://github.com/user-attachments/assets/2c488c58-ff69-42e5-aa20-0b8e174f416f)](https://os-checker.github.io/book/checkers.html)
+[![Image](https://github.com/user-attachments/assets/67ca6f1f-967c-4eea-8050-5678fc1fa59c)](https://os-checker.github.io/book/checkers.html)
 
 此外，os-checker 生成包括基础信息：
 * Cargo.toml：Package 维度；由许多工具读取和使用，应该正确维护

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,3 +1,3 @@
 {
-  "os-checker/os-checker-test-suite": {}
+  "arceos-org/percpu": {}
 }

--- a/src/config/checker.rs
+++ b/src/config/checker.rs
@@ -49,6 +49,26 @@ impl CheckerTool {
         }
     }
 
+    pub fn from_str(s: &str) -> Option<Self> {
+        Some(match s {
+            "fmt" => Fmt,
+            "clippy" => Clippy,
+            "miri" => Miri,
+            "semver-checks" => SemverChecks,
+            "audit" => Audit,
+            "mirai" => Mirai,
+            "lockbud" => Lockbud,
+            "atomvchecker" => Atomvchecker,
+            "rapx" => Rapx,
+            "rudra" => Rudra,
+            "outdated" => Outdated,
+            "geiger" => Geiger,
+            "udeps" => Udeps,
+            "cargo" => Cargo,
+            _ => return None,
+        })
+    }
+
     /// To reduce outdated artifacts of other checkers,
     /// call cargo clean before some checkers start.
     pub fn cargo_clean(self, workspace_dirs: &[&Utf8Path]) {

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -10,7 +10,10 @@ use super::{cmd::*, CheckerTool};
 use crate::{
     layout::{Audit, Pkg},
     output::{get_toolchain, host_target_triple},
-    utils::HOST_TARGET,
+    utils::{
+        env_var::{force_run_check, ForceRunCheck},
+        HOST_TARGET,
+    },
     Result, XString,
 };
 use cargo_metadata::camino::Utf8PathBuf;
@@ -183,7 +186,11 @@ impl Resolve {
 
     /// force checking even if a cache exists
     pub fn force_check(&self) -> bool {
-        matches!(self.checker, CheckerTool::Mirai | CheckerTool::Lockbud)
+        match force_run_check() {
+            ForceRunCheck::False => false,
+            ForceRunCheck::All => true,
+            ForceRunCheck::Partial(v) => v.iter().any(|tool| self.checker == *tool),
+        }
     }
 
     pub fn outdated(pkgs: &[Pkg], resolved: &mut Vec<Self>) {

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -189,7 +189,7 @@ impl Resolve {
         match force_run_check() {
             ForceRunCheck::False => false,
             ForceRunCheck::All => true,
-            ForceRunCheck::Partial(v) => v.iter().any(|tool| self.checker == *tool),
+            ForceRunCheck::Partial(v) => v.contains(&self.checker),
         }
     }
 

--- a/src/run_checker/mod.rs
+++ b/src/run_checker/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{CacheRepo, InfoKeyValue},
     layout::{Audit, Layout},
     output::JsonOutput,
-    utils::Exclude,
+    utils::{env_var::force_repo_check, Exclude},
     Result, XString,
 };
 use cargo_metadata::{
@@ -273,7 +273,7 @@ impl RepoOutput {
             }
         };
 
-        if utils::force_repo_check() || config.rerun() {
+        if force_repo_check() || config.rerun() {
             warn!("强制运行检查（不影响已有的检查缓存结果）");
         } else if let Some(db) = config.db() {
             match info.get_from_db(db) {
@@ -446,8 +446,8 @@ fn run_check(
 ) -> Result<()> {
     // 从缓存中获取结果，如果获取成功，则不执行实际的检查
     // FIXME: 当 force_check 后如果 Cargo 不再有诊断，那么下次读取缓存的话，那么会看到旧的 Cargo 诊断？
-    // if !utils::force_run_check() && !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo)     {
-    if !utils::force_run_check() && outputs.fetch_cache(&resolve, db_repo) {
+    if !resolve.force_check() && outputs.fetch_cache(&resolve, db_repo) {
+        // if !utils::force_run_check() && outputs.fetch_cache(&resolve, db_repo) {
         return Ok(());
     }
 

--- a/src/run_checker/utils.rs
+++ b/src/run_checker/utils.rs
@@ -12,36 +12,7 @@ use crate::{
     Result,
 };
 use cargo_metadata::camino::Utf8Path;
-use std::{fmt::Write, sync::LazyLock};
-
-struct Global {
-    force_repo_check: bool,
-    force_run_check: bool,
-}
-
-fn var(env: &str) -> Option<bool> {
-    std::env::var(env)
-        .map(|val| matches!(&*val, "true" | "1"))
-        .ok()
-}
-
-static GLOBAL: LazyLock<Global> = LazyLock::new(|| Global {
-    force_repo_check: var("FORCE_REPO_CHECK").unwrap_or(false),
-    force_run_check: var("FORCE_RUN_CHECK").unwrap_or(false),
-});
-
-/// 当 os-checker 内部支持新检查时，将这个值设置为 true，
-/// 来强制运行仓库检查（不影响已有的检查缓存结果）。
-/// NOTE: cargo error 的检查结果总是在强制运行仓库检查时更新。
-pub fn force_repo_check() -> bool {
-    GLOBAL.force_repo_check
-}
-
-/// 当运行到 run_check 时，是否强制运行检查，不检查是否有缓存。
-/// force_repo_check 会控制是否运行 run_check，而 force_run_check 会控制是否照顾缓存。
-pub fn force_run_check() -> bool {
-    GLOBAL.force_run_check
-}
+use std::fmt::Write;
 
 /// 将一次工具的检查命令推入一次 `Vec<Idx>`，并把原始输出全部推入 `Vec<Data>`。
 pub fn push_idx_and_data(

--- a/src/utils/env_var.rs
+++ b/src/utils/env_var.rs
@@ -34,7 +34,9 @@ pub enum ForceRunCheck {
 impl ForceRunCheck {
     /// * FORCE_RUN_CHECK=tool or tool,tool2,... => Partial
     /// * FORCE_RUN_CHECK=true or all => All
-    /// * FORCE_RUN_CHECK=anything-else or unset => False
+    /// * FORCE_RUN_CHECK=false or unset => False
+    ///
+    /// Invalid value will just panic.
     fn new() -> Self {
         match var(FORCE_REPO_CHECK).map(|s| s.trim().to_ascii_lowercase()) {
             Ok(var) if !var.is_empty() => {
@@ -55,7 +57,7 @@ impl ForceRunCheck {
                 } else if var == "true" || var == "all" {
                     ForceRunCheck::All
                 } else {
-                    ForceRunCheck::False
+                    panic!("{var} is invalid: only accept false, true, or a set of checkers.")
                 }
             }
             _ => ForceRunCheck::False,

--- a/src/utils/env_var.rs
+++ b/src/utils/env_var.rs
@@ -38,7 +38,7 @@ impl ForceRunCheck {
     ///
     /// Invalid value will just panic.
     fn new() -> Self {
-        match var(FORCE_REPO_CHECK).map(|s| s.trim().to_ascii_lowercase()) {
+        match var(FORCE_RUN_CHECK).map(|s| s.trim().to_ascii_lowercase()) {
             Ok(var) if !var.is_empty() => {
                 let sep = ',';
                 if var.contains(sep) {
@@ -56,6 +56,8 @@ impl ForceRunCheck {
                     ForceRunCheck::Partial(vec![tool])
                 } else if var == "true" || var == "all" {
                     ForceRunCheck::All
+                } else if var == "false" {
+                    ForceRunCheck::False
                 } else {
                     panic!("{var} is invalid: only accept false, true, or a set of checkers.")
                 }

--- a/src/utils/env_var.rs
+++ b/src/utils/env_var.rs
@@ -1,0 +1,70 @@
+use crate::config::CheckerTool;
+use std::{env::var, sync::LazyLock};
+
+const FORCE_REPO_CHECK: &str = "FORCE_REPO_CHECK";
+const FORCE_RUN_CHECK: &str = "FORCE_RUN_CHECK";
+
+struct Global {
+    force_repo_check: bool,
+    force_run_check: ForceRunCheck,
+}
+
+fn var_bool(env: &str) -> Option<bool> {
+    var(env).map(|val| matches!(&*val, "true" | "1")).ok()
+}
+
+static GLOBAL: LazyLock<Global> = LazyLock::new(|| Global {
+    force_repo_check: var_bool(FORCE_REPO_CHECK).unwrap_or(false),
+    force_run_check: ForceRunCheck::new(),
+});
+
+/// 当 os-checker 内部支持新检查时，将这个值设置为 true，
+/// 来强制运行仓库检查（不影响已有的检查缓存结果）。
+/// NOTE: cargo error 的检查结果总是在强制运行仓库检查时更新。
+pub fn force_repo_check() -> bool {
+    GLOBAL.force_repo_check
+}
+
+pub enum ForceRunCheck {
+    False,
+    All,
+    Partial(Vec<CheckerTool>),
+}
+
+impl ForceRunCheck {
+    /// * FORCE_RUN_CHECK=tool or tool,tool2,... => Partial
+    /// * FORCE_RUN_CHECK=true or all => All
+    /// * FORCE_RUN_CHECK=anything-else or unset => False
+    fn new() -> Self {
+        match var(FORCE_REPO_CHECK).map(|s| s.trim().to_ascii_lowercase()) {
+            Ok(var) if !var.is_empty() => {
+                let sep = ',';
+                if var.contains(sep) {
+                    let v: Vec<_> = var
+                        .split(',')
+                        .map(|s| {
+                            CheckerTool::from_str(s).unwrap_or_else(|| {
+                                panic!("{s:?} in {var:?} isn't a valid CheckerTool")
+                            })
+                        })
+                        .collect();
+                    assert!(!v.is_empty());
+                    ForceRunCheck::Partial(v)
+                } else if let Some(tool) = CheckerTool::from_str(&var) {
+                    ForceRunCheck::Partial(vec![tool])
+                } else if var == "true" || var == "all" {
+                    ForceRunCheck::All
+                } else {
+                    ForceRunCheck::False
+                }
+            }
+            _ => ForceRunCheck::False,
+        }
+    }
+}
+
+/// 当运行到 run_check 时，是否强制运行检查，不检查是否有缓存。
+/// force_repo_check 会控制是否运行 run_check，而 force_run_check 会控制是否照顾缓存。
+pub fn force_run_check() -> &'static ForceRunCheck {
+    &GLOBAL.force_run_check
+}

--- a/src/utils/installation.rs
+++ b/src/utils/installation.rs
@@ -49,6 +49,7 @@ pub fn rustup_target_add_for_checkers(targets: &[&str]) -> Result<()> {
     install_targets(super::PLUS_TOOLCHAIN_HOST)?;
 
     install_targets(super::PLUS_TOOLCHAIN_LOCKBUD)?;
+    install_targets(super::PLUS_TOOLCHAIN_ATOMVCHECKER)?;
     install_targets(super::PLUS_TOOLCHAIN_MIRAI)?;
     install_targets(super::PLUS_TOOLCHAIN_RAP)?;
 
@@ -84,6 +85,7 @@ fn detect_checker_if_exists(checker_bin: &str) -> Result<()> {
 fn detect_checkers() -> Result<()> {
     detect_checker_if_exists("rapx")?;
     detect_checker_if_exists("lockbud")?;
+    detect_checker_if_exists("atomvchecker")?;
     detect_checker_if_exists("mirai")?;
     detect_checker_if_exists("rudra")?;
     Ok(())

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,8 @@ use duct::cmd;
 use eyre::Context;
 use std::{path::Path, time::Instant};
 
+pub mod env_var;
+
 mod scan_for_targets;
 pub use scan_for_targets::scan_scripts_for_target;
 


### PR DESCRIPTION
This PR
* auto installs targets on toolchain required by AtomVChecker 
  * closes https://github.com/os-checker/os-checker/issues/374
*  adjusts `FORCE_RUN_CHECK` to accept a set of checkers, such as `tool1,tool2`, which is handy when rerunning all checks from a specified checker