### PR TITLE
Chore: prune configs of repo that don't exist in refined_list.txt

### DIFF
--- a/assets/repos-ui.json
+++ b/assets/repos-ui.json
@@ -31,7 +31,7 @@
       }
     }
   },
-  "ZR233/arm-gic-driver": {
+  "rcore-os/arm-gic-driver": {
     "targets": "aarch64-unknown-none-softfloat"
   }
 }


### PR DESCRIPTION
This PR removes repos that don't exist in refined_list.txt which was introduced in these PRs
* https://github.com/kern-crates/.github/pull/59
* https://github.com/kern-crates/.github/pull/61
* https://github.com/kern-crates/.github/pull/62

Basically, these repos are most important reusable component OS libraries.

This PR reduces count of repos to 60 with 1.7K diagnostics.

![](https://github.com/user-attachments/assets/70f7995b-680f-4ce4-bedd-6b8aff7d61e3)
