### PR TITLE
Feat: Update checkers and default toolchain

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -18,15 +18,15 @@ env:
   # true: run with json file emitted, and push it to database.
   PUSH: true
   # default nightly toolchain version
-  toolchain: nightly-2025-06-26
+  toolchain: nightly-2025-12-06
   # /mnt has more space than root folder
   BASE_DIR: /mnt/check
   # push to which database branch 
   DATABASE: main
   # cache.redb tag in database release
-  TAG_CACHE: cache-os-checker-v0.8.0.redb
+  TAG_CACHE: cache-os-checker-v0.8.1.redb
   # checkers in database release
-  TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.0.redb
+  TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.1.redb
   # force downloading repos to run check 
   FORCE_REPO_CHECK: false
   # force running checks after downloading repos
@@ -79,7 +79,7 @@ jobs:
           cargo udeps --version
           rustup default nightly-2025-01-10 && cargo mirai --help
           rustup default nightly-2025-02-01 && cargo lockbud --help
-          rustup default nightly-2024-10-12 && cargo rapx --help
+          rustup default nightly-2025-12-06 && cargo rapx --help
           rustup default nightly-2021-10-21 && cargo rudra --help
           rustup default nightly-2023-03-09 && cargo atomvchecker --help
           rustup default ${{ env.toolchain }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -77,6 +77,7 @@ jobs:
           cargo geiger --version
           cargo semver-checks --version
           cargo udeps --version
+          cargo nextest --version
           rustup default nightly-2025-01-10 && cargo mirai --help
           rustup default nightly-2025-02-01 && cargo lockbud --help
           rustup default nightly-2025-12-06 && cargo rapx --help

--- a/src/config/cmd.rs
+++ b/src/config/cmd.rs
@@ -144,6 +144,7 @@ pub fn cargo_rap(pkg: &Pkg) -> Resolve {
         "rapx",
         "-F",
         "-M",
+        "-timeout=300",
         "--",
         "--target",
         pkg.target,

--- a/src/config/deserialization/config_options.rs
+++ b/src/config/deserialization/config_options.rs
@@ -136,7 +136,7 @@ fn default_checkers(run_all_checkers: bool) -> IndexMap<CheckerTool, EnableOrCus
         Atomvchecker => state(),
         Mirai => state(),
         Audit => state(),
-        Rapx => state(),
+        Rapx => DISABLE,
         Rudra => state(),
         Outdated => state(),
         Geiger => state(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -25,13 +25,13 @@ pub const PECULIAR_TARGETS: &[&str] = &["x86_64-fuchsia", "avr-unknown-gnu-atmeg
 pub const HOST_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 /// 检查工具固定的工具链
-pub const PLUS_TOOLCHAIN_HOST: &str = "+nightly-2025-06-26";
+pub const PLUS_TOOLCHAIN_HOST: &str = "+nightly-2025-12-06";
 
 pub const PLUS_TOOLCHAIN_RUDRA: &str = "+nightly-2021-10-21";
 pub const PLUS_TOOLCHAIN_MIRAI: &str = "+nightly-2025-01-10";
 pub const PLUS_TOOLCHAIN_LOCKBUD: &str = "+nightly-2025-02-01";
 pub const PLUS_TOOLCHAIN_ATOMVCHECKER: &str = "+nightly-2023-03-09";
-pub const PLUS_TOOLCHAIN_RAP: &str = "+nightly-2024-10-12";
+pub const PLUS_TOOLCHAIN_RAP: &str = "+nightly-2025-12-06";
 
 /// git clone 一个仓库到一个 dir。
 /// 如果该仓库已存在，则 git pull 拉取最新的代码。


### PR DESCRIPTION
This PR bumps versions of checkers and toolchains: 

| checker |  before | after |
|-|-|-|
|default toolchain | nightly-2025-06-26 | nightly-2025-12-06 |
|rapx| nightly-2024-10-12 | nightly-2025-12-06|
| cargo-semver-checks | 030af20 | 04585c |
|cargo-updes| v0.1.56  | v0.1.60|
| cargo-audit| v0.21.2|v0.22.0|
|cargo-geiger|v0.12.0|v0.13.0|
|cargo-nextest| | v0.9.115|

* The update fixes https://github.com/os-checker/os-checker/issues/417.
* RAPx has a 5 minutes timeout, but the check is disabled by default because it hits the timeout too much.
* CI now pulls the checker bin bundle and pushs the data to cache-os-checker-v0.8.1.redb tag in  database repo.