### PR TITLE
Chore: adjust configs for drivercraft/CrabUSB and Asterinas

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,12 +28,12 @@ env:
   # checkers in database release
   TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.1.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # force running checks after downloading repos
   FORCE_RUN_CHECK: false
   # use which configs
-  OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,9 +28,9 @@ env:
   # checkers in database release
   TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.1.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: true
+  FORCE_REPO_CHECK: false
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: true
+  FORCE_RUN_CHECK: false
   # use which configs
   OS_CHECKER_CONFIGS: repos.json # for debug single repo
   # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,7 +28,7 @@ env:
   # checkers in database release
   TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.1.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # force running checks after downloading repos
   FORCE_RUN_CHECK: false
   # use which configs

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,12 +28,12 @@ env:
   # checkers in database release
   TAG_PRECOMPILED_CHECKERS: cache-os-checker-v0.8.1.redb
   # force downloading repos to run check 
-  FORCE_REPO_CHECK: false
+  FORCE_REPO_CHECK: true
   # force running checks after downloading repos
-  FORCE_RUN_CHECK: false
+  FORCE_RUN_CHECK: true
   # use which configs
-  # OS_CHECKER_CONFIGS: repos.json # for debug single repo
-  OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
+  OS_CHECKER_CONFIGS: repos.json # for debug single repo
+  # OS_CHECKER_CONFIGS: repos-default.json repos-ui.json # full repo list
 
 jobs:
   run:

--- a/assets/repos-ui.json
+++ b/assets/repos-ui.json
@@ -93,5 +93,18 @@
         "targets": "x86_64-unknown-linux-gnu"
       }
     }
+  },
+  "drivercraft/CrabUSB": {
+    "packages": {
+      "usb-keyboard": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "uvc-frame-parser": {
+        "targets": "x86_64-unknown-linux-gnu"
+      },
+      "test_libusb_uvc": {
+        "targets": "x86_64-unknown-linux-gnu"
+      }
+    }
   }
 }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,13 +1,26 @@
 {
-  "drivercraft/CrabUSB": {
+  "asterinas/asterinas": {
+    "setup": [
+      "git clone https://github.com/asterinas/linux_vdso /tmp/linux_vdso",
+      "make build"
+    ],
+    "env": {
+      "VDSO_LIBRARY_DIR": "/tmp/linux_vdso"
+    },
+    "meta": {
+      "skip_pkg_dir_globs": [
+        "comp-sys*",
+        "examples_in_book*"
+      ]
+    },
     "packages": {
-      "usb-keyboard": {
+      "cargo-osdk": {
         "targets": "x86_64-unknown-linux-gnu"
       },
-      "uvc-frame-parser": {
+      "sctrace": {
         "targets": "x86_64-unknown-linux-gnu"
       },
-      "test_libusb_uvc": {
+      "linux-bzimage-builder": {
         "targets": "x86_64-unknown-linux-gnu"
       }
     }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -1,26 +1,13 @@
 {
-  "asterinas/asterinas": {
-    "setup": [
-      "git clone https://github.com/asterinas/linux_vdso /tmp/linux_vdso",
-      "make build"
-    ],
-    "env": {
-      "VDSO_LIBRARY_DIR": "/tmp/linux_vdso"
-    },
-    "meta": {
-      "skip_pkg_dir_globs": [
-        "comp-sys*",
-        "examples_in_book*"
-      ]
-    },
+  "drivercraft/CrabUSB": {
     "packages": {
-      "cargo-osdk": {
+      "usb-keyboard": {
         "targets": "x86_64-unknown-linux-gnu"
       },
-      "sctrace": {
+      "uvc-frame-parser": {
         "targets": "x86_64-unknown-linux-gnu"
       },
-      "linux-bzimage-builder": {
+      "test_libusb_uvc": {
         "targets": "x86_64-unknown-linux-gnu"
       }
     }

--- a/assets/repos.json
+++ b/assets/repos.json
@@ -22,6 +22,9 @@
       },
       "linux-bzimage-builder": {
         "targets": "x86_64-unknown-linux-gnu"
+      },
+      "linux-bzimage-setup": {
+        "targets": "x86_64-unknown-linux-gnu"
       }
     }
   }


### PR DESCRIPTION
The following crates are checked only on host target:
* drivercraft/CrabUSB: usb-keyboard, uvc-frame-parser, and test_libusb_uvc
  * the count is cut down from 11894 to 118, especially crab-usb from 11758 to 28
* Asterinas: linux-bzimage-setup